### PR TITLE
Fix non-op players unable to interact with any entity

### DIFF
--- a/org/wargamer2010/signshop/listeners/SignShopHangingListener.java
+++ b/org/wargamer2010/signshop/listeners/SignShopHangingListener.java
@@ -1,4 +1,3 @@
-
 package org.wargamer2010.signshop.listeners;
 
 import org.bukkit.Material;
@@ -56,8 +55,8 @@ public class SignShopHangingListener implements Listener {
                 if(seller.getOwner().equals(ssPlayer.getName()))
                     return;
             }
+            event.setCancelled(true);
+            ssPlayer.sendMessage(SignShopConfig.getError("not_allowed_to_rotate_frame", null));
         }
-        event.setCancelled(true);
-        ssPlayer.sendMessage(SignShopConfig.getError("not_allowed_to_rotate_frame", null));
     }
 }


### PR DESCRIPTION
Without this fix, non-op players are unable to interact with any entity, preventing actions like:
- Taming animals
- Placing paintings
- Shearing sheep

Instead, it would show the "not_allowed_to_rotate_frame" message.
