### PR TITLE
Add .doubleValue() for Essentials worth

### DIFF
--- a/org/wargamer2010/signshop/listeners/SignShopWorthListener.java
+++ b/org/wargamer2010/signshop/listeners/SignShopWorthListener.java
@@ -1,4 +1,3 @@
-
 package org.wargamer2010.signshop.listeners;
 
 import com.earth2me.essentials.Worth;
@@ -40,7 +39,7 @@ public class SignShopWorthListener implements Listener {
     }
 
     public static double getPrice(ItemStack stack) {
-        return wWorth.getPrice(stack);
+        return wWorth.getPrice(stack).doubleValue();
     }
 
     public static boolean essLoaded() {


### PR DESCRIPTION
A recent pull caused the double of Essentials "worth" to change to a BigDecimal. This is a quick fix for the problem
src: https://github.com/essentials/Essentials/pull/587
