### PR TITLE
Change event priority

### DIFF
--- a/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
+++ b/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
@@ -137,7 +137,7 @@ public class SignShopPlayerListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.LOW)
     public void onPlayerInteract(PlayerInteractEvent event) {
         // Respect protection plugins
         if(event.getClickedBlock() == null


### PR DESCRIPTION
The event priority should not be realtime. Lowering this to "LOW" will allow third party plugins to do a check before signshop does (f.ex. interact loggers, Anti-lagg tools ,etc)
