### PR TITLE
Proposal: !cooldownminutesleft as minutes variant of !cooldownleft

### DIFF
--- a/org/wargamer2010/signshop/listeners/sslisteners/ShopCooldown.java
+++ b/org/wargamer2010/signshop/listeners/sslisteners/ShopCooldown.java
@@ -37,6 +37,11 @@ public class ShopCooldown implements Listener {
                 event.setMessagePart("!cooldownleft", Long.toString(left));
             else
                 event.setMessagePart("!cooldownleft", "< 1");
+                
+            if(left >= 60)
+                event.setMessagePart("!cooldownminutesleft", Long.toString(left/60));
+            else
+                event.setMessagePart("!cooldownminutesleft", "< 1");
             event.getPlayer().sendMessage(SignShopConfig.getError("shop_on_cooldown", event.getMessageParts()));
             event.setCancelled(true);
             return;

--- a/org/wargamer2010/signshop/operations/cooldown.java
+++ b/org/wargamer2010/signshop/operations/cooldown.java
@@ -59,7 +59,12 @@ public class cooldown implements SignShopOperation {
                     ssArgs.setMessagePart("!cooldownleft", Long.toString(left));
                 else
                     ssArgs.setMessagePart("!cooldownleft", "< 1");
-
+                    
+                if(left >= 60)
+                    event.setMessagePart("!cooldownminutesleft", Long.toString(left/60));
+                else
+                    event.setMessagePart("!cooldownminutesleft", "< 1");
+                
                 ssPlayer.sendMessage(SignShopConfig.getError("shop_on_cooldown", ssArgs.getMessageParts()));
                 return false;
             }


### PR DESCRIPTION
We use a custom SignShop sign that behaves as a 24 hour ATM, using the following code:

    ATM: givePlayerMoney,cooldown{82800},playerIsOp

As a nicety, I'd like to propose the addition of `!cooldownminutesleft` so that we can have the `shop_on_cooldown` message use minutes instead of seconds.

*Although I am confident the changed code has no errors, I am unable to try building or testing it.*