### PR TITLE
Update LWCHook for UUIDs

### DIFF
--- a/org/wargamer2010/signshop/hooks/LWCHook.java
+++ b/org/wargamer2010/signshop/hooks/LWCHook.java
@@ -36,7 +36,7 @@ public class LWCHook implements Hook {
             return false;
         if(lwc.findProtection(block) == null) {
             Protection prot = lwc.getPhysicalDatabase().registerProtection(block.getTypeId(), Protection.Type.PRIVATE,
-                    block.getWorld().getName(), player.getName(), "", block.getX(), block.getY(), block.getZ());
+                    block.getWorld().getName(), player.getUniqueId().toString(), "", block.getX(), block.getY(), block.getZ());
             lwc.getPhysicalDatabase().saveProtection(prot);
             return true;
         }


### PR DESCRIPTION
The LWC Hook uses the player name right now. So if a player change this name, LWC cant detect that right now if its locked by sign shops lwc hook. 

https://github.com/Hidendra/LWC/commit/67ab525613f8d71b038dcd254d342cbeac16f786#diff-05e9d8cb28ea56b4c39f9b0aad17578b

Thanks.