### PR TITLE
Fix item loss from canTakeItems not correctly identifying full player inventory

### DIFF
--- a/org/wargamer2010/signshop/player/VirtualInventory.java
+++ b/org/wargamer2010/signshop/player/VirtualInventory.java
@@ -162,7 +162,7 @@ public class VirtualInventory {
     }
 
     private int findSpace(ItemStack item, Map<Integer, StackWithAmount> lookaside, boolean findEmpty) {
-        ItemStack[] stacks = inventory.getContents();
+        ItemStack[] stacks = inventory.getStorageContents();
         if (item == null) {
             return -1;
         }


### PR DESCRIPTION
This is a fix for a major bug discovered on our server. When a player attempts to use a `[Buy]` sign whilst their inventory is full, the shop's items are destroyed and the player's money is taken.

I tracked the issue down to `findSpace()` as used by `canTakeItems()` in `VirtualInventory`. It checks for empty slots in the player's whole inventory, even if some of those slots are _read-only_.

# Testing

* Developed against Spigot API 1.9.4 and Java 8
* Tested on PaperSpigot 1.9.4 b773 local server with EssentialsX and Vault
* Tested on PaperSpigot 1.9.4 b772 live server with 30 plugins
    *  `CleanroomGenerator, dynmap, WorldEdit, DaFlightManager, Skript, TerrainControl, Titanic, zPermissions, Chairs, WorldBorder, TicketMaster, ProtocolLib, Multiverse-Core, WorldGuard, NoCheatPlus, WoodCutter, Stables, HappyPet, SQLibrary, Multiverse-Portals, Vault, Prism, Essentials, PerWorldInventory, LWC, SignShop, VanishNoPacket, CraftBook, Multiverse-NetherPortals, PurpleIRC`

# Notes

* [A built jar of the latest available SignShop (2.11.0) with this fix can be found here](https://github.com/Gamealition/GSignShop/releases)
* As this code change was made and tested on our [downstream fork](https://github.com/Gamealition/GSignShop), I cannot guarantee that this pull request has no compilation nor runtime errors
* This bug was discovered by two of our players; StitchHasAGlitch and Vasha