### PR TITLE
Replace use of reflection for written book data

### DIFF
--- a/org/wargamer2010/signshop/blocks/BookFactory.java
+++ b/org/wargamer2010/signshop/blocks/BookFactory.java
@@ -1,6 +1,8 @@
 
 package org.wargamer2010.signshop.blocks;
 
+import org.bukkit.inventory.meta.BookMeta;
+
 public class BookFactory {
     private BookFactory() {
 
@@ -17,7 +19,16 @@ public class BookFactory {
     }
 
     public static IBookItem getBookItem(org.bukkit.inventory.ItemStack stack) {
-        return new BookItem(stack);
+
+        try {
+            // Bukkit API 1.9.4+
+            BookMeta.Generation.class.isEnum();
+            return new BookItem(stack);
+        } catch( NoClassDefFoundError e ) {
+            // Bukkit API 1.8.8-
+            return new LegacyBookItem(stack);
+        }
+
     }
 
     public static IItemTags getItemTags() {

--- a/org/wargamer2010/signshop/blocks/BookItem.java
+++ b/org/wargamer2010/signshop/blocks/BookItem.java
@@ -1,22 +1,17 @@
 package org.wargamer2010.signshop.blocks;
 
-import java.lang.reflect.Field;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.BookMeta.Generation;
+import org.wargamer2010.signshop.SignShop;
+
 import java.util.Arrays;
 import java.util.logging.Level;
 
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BookMeta;
-import org.wargamer2010.signshop.SignShop;
-
 public class BookItem implements IBookItem {
 
-        private BookMeta meta = null;
-        private ItemStack _stack = null;
-
-        private static boolean attemptedReflection = false;
-        private static Field reflectedGenerationField = null;
-
-        private static final String generationError = "Failed to set Generation for Written Book, API might have changed. Please report this problem.";
+        protected BookMeta meta = null;
+        protected ItemStack _stack = null;
 
         public BookItem(org.bukkit.inventory.ItemStack pItem) {
             if(pItem.getItemMeta() instanceof BookMeta) {
@@ -50,18 +45,9 @@ public class BookItem implements IBookItem {
 
         @Override
         public Integer getGeneration() {
-            Field field = getGenerationField();
-            if(field == null)
-                return null;
-            try {
-                return (Integer)field.get(meta);
-            } catch (IllegalArgumentException ex) {
-                SignShop.log(generationError, Level.WARNING);
-            } catch (IllegalAccessException ex) {
-                SignShop.log(generationError, Level.WARNING);
-            }
-
-            return null;
+            if(meta == null)
+                return 0;
+            return meta.getGeneration().ordinal();
         }
 
         @Override
@@ -98,16 +84,19 @@ public class BookItem implements IBookItem {
 
         @Override
         public void setGeneration(Integer generation) {
-            Field field = getGenerationField();
-            if(field == null || generation == null)
+            if(meta == null)
                 return;
+            else if(generation == null)
+            {
+                meta.setGeneration(null);
+                return;
+            }
+
             try {
-                field.set(meta, generation);
-                updateMeta();
-            } catch (IllegalArgumentException ex) {
-                SignShop.log(generationError, Level.WARNING);
-            } catch (IllegalAccessException ex) {
-                SignShop.log(generationError, Level.WARNING);
+                Generation enumGen = Generation.values()[generation];
+                meta.setGeneration(enumGen);
+            } catch(ArrayIndexOutOfBoundsException e) {
+                SignShop.log("Book's generation is out of bounds; leaving as default (ORIGINAL)", Level.WARNING);
             }
         }
 
@@ -128,30 +117,7 @@ public class BookItem implements IBookItem {
             return _stack;
         }
 
-        private void updateMeta() {
+        protected void updateMeta() {
             _stack.setItemMeta(meta);
-        }
-
-        private Field getGenerationField() {
-            if(meta == null)
-                return null;
-            if(attemptedReflection)
-                return reflectedGenerationField;
-
-            try {
-                reflectedGenerationField = meta.getClass().getSuperclass().getDeclaredField("generation");
-                reflectedGenerationField.setAccessible(true);
-            }
-            catch (NoSuchFieldException ex) { reflectedGenerationField = null; }
-            catch (SecurityException ex) { reflectedGenerationField = null; }
-            catch (IllegalArgumentException ex) { reflectedGenerationField = null; }
-
-            attemptedReflection = true;
-
-            if(reflectedGenerationField == null) {
-                SignShop.log(generationError, Level.WARNING);
-            }
-
-            return reflectedGenerationField;
         }
 }

--- a/org/wargamer2010/signshop/blocks/BookItem.java
+++ b/org/wargamer2010/signshop/blocks/BookItem.java
@@ -23,7 +23,7 @@ public class BookItem implements IBookItem {
 
         @Override
         public String[] getPages() {
-            if(meta == null)
+            if(meta == null || !meta.hasPages())
                 return new String[1];
             String[] arr = new String[meta.getPages().size()];
             return meta.getPages().toArray(arr);
@@ -31,21 +31,22 @@ public class BookItem implements IBookItem {
 
         @Override
         public String getAuthor() {
-            if(meta == null)
+            if(meta == null || !meta.hasAuthor())
                 return "";
             return meta.getAuthor();
         }
 
         @Override
         public String getTitle() {
-            if(meta == null)
+            if(meta == null || !meta.hasTitle())
                 return "";
             return meta.getTitle();
         }
 
         @Override
         public Integer getGeneration() {
-            if(meta == null)
+            // Some 1.9.4 servers are missing .hasGeneration()
+            if(meta == null || meta.getGeneration() == null)
                 return 0;
             return meta.getGeneration().ordinal();
         }

--- a/src/main/java/org/wargamer2010/signshop/blocks/LegacyBookItem.java
+++ b/src/main/java/org/wargamer2010/signshop/blocks/LegacyBookItem.java
@@ -1,0 +1,74 @@
+package org.wargamer2010.signshop.blocks;
+
+import org.bukkit.inventory.ItemStack;
+import org.wargamer2010.signshop.SignShop;
+
+import java.lang.reflect.Field;
+import java.util.logging.Level;
+
+/** Adds backwards compatibility for Generation API missing before Bukkit 1.8.8 */
+public class LegacyBookItem extends BookItem {
+
+        private static boolean attemptedReflection = false;
+        private static Field reflectedGenerationField = null;
+
+        private static final String generationError = "Failed to set Generation for Written Book. Please report this problem.";
+
+        public LegacyBookItem(ItemStack pItem) {
+            super(pItem);
+        }
+
+        @Override
+        public Integer getGeneration() {
+            Field field = getGenerationField();
+            if(field == null)
+                return null;
+            try {
+                return (Integer)field.get(meta);
+            } catch (IllegalArgumentException ex) {
+                SignShop.log(generationError, Level.WARNING);
+            } catch (IllegalAccessException ex) {
+                SignShop.log(generationError, Level.WARNING);
+            }
+
+            return null;
+        }
+
+        @Override
+        public void setGeneration(Integer generation) {
+            Field field = getGenerationField();
+            if(field == null || generation == null)
+                return;
+            try {
+                field.set(meta, generation);
+                updateMeta();
+            } catch (IllegalArgumentException ex) {
+                SignShop.log(generationError, Level.WARNING);
+            } catch (IllegalAccessException ex) {
+                SignShop.log(generationError, Level.WARNING);
+            }
+        }
+
+        private Field getGenerationField() {
+            if(meta == null)
+                return null;
+            if(attemptedReflection)
+                return reflectedGenerationField;
+
+            try {
+                reflectedGenerationField = meta.getClass().getSuperclass().getDeclaredField("generation");
+                reflectedGenerationField.setAccessible(true);
+            }
+            catch (NoSuchFieldException ex) { reflectedGenerationField = null; }
+            catch (SecurityException ex) { reflectedGenerationField = null; }
+            catch (IllegalArgumentException ex) { reflectedGenerationField = null; }
+
+            attemptedReflection = true;
+
+            if(reflectedGenerationField == null) {
+                SignShop.log(generationError, Level.WARNING);
+            }
+
+            return reflectedGenerationField;
+        }
+}


### PR DESCRIPTION
This PR makes SignShop use the [new written book generation API I had written for Spigot/Bukkit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/pull-requests/193/overview), back in May.

I believe this PR, [in combination with another fix I made for CraftBukkit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/pull-requests/198/overview), will properly fix #21 for 1.9.4+.

# Testing

* Developed against Spigot API 1.10.2 and Java 8
* Tested on PaperSpigot 1.10.2 b837 local server with EssentialsX and Vault - OK
* Tested on PaperSpigot 1.9.4 b773 local server with EssentialsX and Vault - OK
* Tested on PaperSpigot 1.8.8 b443 local server with EssentialsX and Vault - OK
* Not yet tested on live server (as of 22 August commits)

## Checklist

### 1.10.2 only

* [x] Can setup written book of `ORIGINAL`, `COPY_OF_ORIGINAL`, `COPY_OF_COPY` and `TATTERED` for buy and sell
* [x] Can setup written books of multiple generations for buy and sell
* [x] Shop stock differentiates between books of different generations
* [x] Shop stock differentiates between books of different authors
* [x] Shop stock differentiates between books of different contents
* [x] All of the above works after `/signshop reload`

### 1.8.8 only

* [x] Shops handling written books load without exceptions
* [x] Shops handling written books created without exceptions

# Notes

* [A built jar of the latest available SignShop (2.11.0) with this fix can be found here](https://github.com/Gamealition/GSignShop/releases)
* As this code change was made and tested on our [downstream fork](https://github.com/Gamealition/GSignShop), I cannot guarantee that this pull request has no compilation nor runtime errors