### PR TITLE
Fix 1.8.8 compatibility in findSpace

### DIFF
--- a/org/wargamer2010/signshop/player/VirtualInventory.java
+++ b/org/wargamer2010/signshop/player/VirtualInventory.java
@@ -1,13 +1,17 @@
 
 package org.wargamer2010.signshop.player;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.wargamer2010.signshop.configuration.SignShopConfig;
 import org.wargamer2010.signshop.util.itemUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.wargamer2010.signshop.util.itemUtil.StackToMap;
 import static org.wargamer2010.signshop.util.itemUtil.getBackupItemStack;
 
@@ -164,7 +168,11 @@ public class VirtualInventory {
     }
 
     private int findSpace(ItemStack item, Map<Integer, StackWithAmount> lookaside, boolean findEmpty) {
-        ItemStack[] stacks = inventory.getStorageContents();
+        // 1.9.4 and later extend living entity slots beyond 36, but some of these are read-only.
+        // We could use .getStorageContents(), but this breaks 1.8.8 compatibility
+        int length = (inventory.getHolder() instanceof HumanEntity) ? 36 : inventory.getSize();
+        ItemStack[] stacks = Arrays.copyOfRange(inventory.getContents(), 0, length);
+
         if (item == null) {
             return -1;
         }


### PR DESCRIPTION
This is a compatibility fix for my pull request #30. Whilst testing my commits for #34 on PaperSpigot 1.8.8 b443, I found that using sign shops were broken.

This is because, it turns out, `inventory.getStorageContents()` does not exist in Bukkit API 1.8.8. So instead of using `getStorageContents`, I check who/what is holding the inventory. If it's a human-like entity (e.g. a player), then it only copies the 36 storage slots that Minecraft's always had.

# Testing

* Developed against Spigot API 1.10.2 and Java 8
* Tested on PaperSpigot 1.10.2 b837 local server with EssentialsX and Vault - OK
* Tested on PaperSpigot 1.9.4 b773 local server with EssentialsX and Vault - OK
* Tested on PaperSpigot 1.8.8 b443 local server with EssentialsX and Vault - OK
* Not yet tested on live server

## Checklist

* [x] Buying from sign shop with empty slots in my inventory properly allows transaction
* [x] Buying from sign shop with no empty slots in my inventory properly denies transaction
* [x] Selling to sign shop with empty slots in shop's inventory properly allows transaction
* [x] Selling to sign shop with no empty slots in shop's inventory properly denies transaction

# Caveats

This is a lazy fix, as the code will always assume that players will only ever have 36 slots of storage (using a magic value). This means other storage slots (e.g. off-hand slot) are left out of space calculations.

# Notes

* [A built jar of the latest available SignShop (2.11.0) with this fix can be found here](https://github.com/Gamealition/GSignShop/releases)
* As this code change was made and tested on our [downstream fork](https://github.com/Gamealition/GSignShop), I cannot guarantee that this pull request has no compilation nor runtime errors