### PR TITLE
Cancel click event on sign if holding link material

### DIFF
--- a/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
+++ b/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
@@ -188,6 +188,7 @@ public class SignShopPlayerListener implements Listener {
                 }
 
 
+                event.setCancelled(true);
                 List<Block> containables = new LinkedList<Block>();
                 List<Block> activatables = new LinkedList<Block>();
                 Boolean wentOK = signshopUtil.getSignshopBlocksFromList(ssPlayer, containables, activatables, bClicked);


### PR DESCRIPTION
When a player left-clicks a sign. . .

* That has a valid SignShop tag (e.g. `[Buy]`) on the first line
* Whilst holding the link material (e.g. redstone dust)

. . .the event is not cancelled. If the player is in creative mode, this causes two problems:

* [If attempting to link a sign and the player forgets to link a chest or fulfill some other precondition first, the sign is inconveniently destroyed anyway](https://gfycat.com/EthicalCleverAnemoneshrimp)
* [If `ProtectShopsInCreative: false` in `config.yml`, a newly created shop gets destroyed in creation time](https://gfycat.com/CheerfulEverlastingIcelandichorse)

This PR fixes both by cancelling the left-click event if:

* The target block is a sign with a valid SignShop tag
* The player is attempting to activate that sign (whether its preconditions are met or not)
* The player is holding the link material

# Testing

*This PR has not yet been thoroughly tested for regressions, nor tested on a live server*

* Developed against Spigot API 1.11 and Java 8
* Tested on PaperSpigot 1.11 b932 local server with EssentialsX and Vault - **OK**
* [Gfycat of fixed behavior to creating shops creatively, after applying this PR](https://gfycat.com/PitifulAjarBighorn)

# Notes

* ~Subjectively, it should be safe to assume that if a player is clicking on a sign with the link material, they are attempting to do something with SignShop to that sign~
* ~However, this may confuse survival players who attempt to break signs whilst holding the link material. They will get an error message but will continue to see the breaking animation, until it eventually fails~
  * See commentary below
* [A built jar of the latest available SignShop (2.11.0) with this fix can be found here](https://github.com/Gamealition/GSignShop/releases/tag/2.11.0rev4)
* As this code change was made and tested on our [downstream fork](https://github.com/Gamealition/GSignShop), I cannot guarantee that this pull request has no compilation nor runtime errors