### PR TITLE
Update PlayerMetadata.java

### DIFF
--- a/org/wargamer2010/signshop/player/PlayerMetadata.java
+++ b/org/wargamer2010/signshop/player/PlayerMetadata.java
@@ -144,6 +144,11 @@ public class PlayerMetadata {
                 SignShopPlayer player = PlayerIdentifier.getPlayerFromString(playername);
                 if(player == null)
                     continue;
+                // Adding a NPE check to solve an issue where SignShop is failing to load.
+                // Presumably the DB file is missing some necessary info, but in the sample
+                // case UUID conversion happened long ago so it does not need to happen again. 
+                if(player.GetIdentifier() == null)
+                    continue;
                 String id = player.GetIdentifier().toString();
                 if(!playername.equalsIgnoreCase(id))
                     toConverts.add(new ToConvert(playername, id, metakey, metavalue));


### PR DESCRIPTION
Adding an NPE check to the identifier on SignShopPlayer during onEnable's UUID Conversion check. This is preventing my SignShop from loading and UUID conversion took place for me already long ago - - no need to crash the plugin here just because an identifier is missing.

_[19:23:59] [Server thread/INFO]: [SignShop] Enabling SignShop v2.11.2
[19:23:59] [Server thread/INFO]: [SignShop] Succesfully started Metrics, see http://mcstats.org for more information.
[19:24:00] [Server thread/ERROR]: Error occurred while enabling SignShop v2.11.2 (Is it up to date?)
java.lang.NullPointerException: null
at org.wargamer2010.signshop.player.PlayerMetadata.convertToUuid(PlayerMetadata.java:147) ~[?:?]
at org.wargamer2010.signshop.SignShop.onEnable(SignShop.java:108) ~[?:?]_