### PR TITLE
Fixes issue when BentoBox blocks other worlds

### DIFF
--- a/src/main/java/org/wargamer2010/signshop/hooks/BentoBoxHook.java
+++ b/src/main/java/org/wargamer2010/signshop/hooks/BentoBoxHook.java
@@ -3,8 +3,8 @@ package org.wargamer2010.signshop.hooks;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import world.bentobox.bentobox.BentoBox;
-import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.managers.IslandsManager;
 
 import java.util.Optional;
@@ -19,15 +19,25 @@ public class BentoBoxHook implements Hook {
     @Override
     public Boolean canBuild(Player player, Block block) {
         if(HookManager.getHook("BentoBox") == null)
+        {
             return true;
-        BentoBox bentoBox = BentoBox.getInstance();
-        User user = User.getInstance(player);
-        IslandsManager islandsManager = bentoBox.getIslands();
-        Optional<Island> island = islandsManager.getIslandAt(block.getLocation());
-        if (island.isPresent() && island.get().getMembers().containsKey(user.getUniqueId())){
-            return  island.get().getMembers().get(user.getUniqueId()) >= 500;
         }
-        return false;
+        
+		BentoBox bentoBox = BentoBox.getInstance();
+
+		// Checks if bentobox operates in given world.
+		if (bentoBox.getIWM().inWorld(block.getWorld()))
+		{
+			// Get the island at given location.
+			Optional<Island> island = bentoBox.getIslands().getIslandAt(block.getLocation());
+
+			// Returns true only if island at the location exist, and player is a member of the island
+			return island.isPresent() &&
+				island.get().getMemberSet(RanksManager.MEMBER_RANK).contains(player.getUniqueId());
+		}
+        
+        // If bentobox does not operates in given world then return true?
+        return true;
     }
 
     @Override


### PR DESCRIPTION
The previous implementation was blocking shops in worlds, where BentoBox does not operate.

This implementation will allow only island members to create the shops. 
BentoBox offers to create a custom "Flag" for an island, that could allow the owner to modify access to creation and using these shops. However, I do not know if it is necessary, and it will overcomplicate things :)