### PR TITLE
Bug fix and more loading info

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -41,13 +41,21 @@
       <option name="IGNORE_POINT_TO_ITSELF" value="false" />
       <option name="myAdditionalJavadocTags" value="" />
     </inspection_tool>
+    <inspection_tool class="MavenPackageUpdate" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="excludeList">
+        <list>
+          <option value="org.xerial:sqlite-jdbc" />
+          <option value="org.bstats:bstats-bukkit" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />
       <option name="processComments" value="true" />
     </inspection_tool>
     <inspection_tool class="WrapperTypeMayBePrimitive" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false">
+    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false" checkParameterExcludingHierarchy="false">
       <option name="LOCAL_VARIABLE" value="true" />
       <option name="FIELD" value="true" />
       <option name="METHOD" value="true" />
@@ -58,6 +66,8 @@
       <option name="ADD_APPLET_TO_ENTRIES" value="true" />
       <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
       <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+      <option name="selected" value="true" />
+      <option name="MIXIN_ENTRY_POINT" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="org.bukkit.event.EventHandler" />
+    </list>
+  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.1.2-dev</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.2</version>
+    <version>3.6.1.3-dev</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.1.2-dev</version>
+    <version>3.6.2</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.1.3-dev</version>
+    <version>3.6.2</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -29,8 +29,8 @@
             <url>https://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
         <repository>
-            <id>rutger-repo</id>
-            <url>http://www.rutgerkok.nl/repo</url>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
     </repositories>
     <dependencies>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations-java5</artifactId>
-            <version>RELEASE</version>
+            <version>22.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -332,7 +332,7 @@ public class SignShopConfig {
             boolean failedOp = false;
             List<String> tempCheckedSignOperation = new LinkedList<>();
 
-            for (String tempOperationString : allSignOperations.get(sKey).split(",")) {
+            for (String tempOperationString : allSignOperations.get(sKey).split("(,(?![^{]*}))")) { //Matches commas outside of curly braces
                 List<String> bits = signshopUtil.getParameters(tempOperationString.trim());
                 String op = bits.get(0);
                 Object opinstance = getInstance(packageName + "." + op.trim());
@@ -875,8 +875,8 @@ public class SignShopConfig {
         RUSSIAN("russian", "ru_RU"),
         SPANISH("spanish", "es_ES");
 
-        String oldName;
-        String localeName;
+        final String oldName;
+        final String localeName;
 
         LanguageSpelling(String oldName, String localeName) {
             this.oldName = oldName;

--- a/src/main/java/org/wargamer2010/signshop/configuration/Storage.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/Storage.java
@@ -59,6 +59,7 @@ public class Storage implements Listener {
 
         // Load into memory, this also removes invalid signs (hence the backup)
         Boolean needToSave = Load();
+
         if(needToSave) {
             File backupTo = new File(ymlFile.getPath()+".bak");
             if(backupTo.exists())
@@ -216,11 +217,13 @@ public class Storage implements Listener {
     }
 
     private Boolean Load() {
+        SignShop.log("Loading and validating shops, please wait...",Level.INFO);
         FileConfiguration yml = YamlConfiguration.loadConfiguration(ymlfile);
         ConfigurationSection sellersection = yml.getConfigurationSection("sellers");
-        if(sellersection == null)
+        if(sellersection == null) {
+            SignShop.log("There are no shops available. This is likely your first startup with SignShop.",Level.INFO);
             return false;
-
+        }
         Map<String,HashMap<String,List<String>>> tempSellers = configUtil.fetchHashmapInHashmapwithList("sellers", yml);
         if(tempSellers == null) {
             SignShop.log("Invalid sellers.yml format detected. Old sellers format is no longer supported."
@@ -229,6 +232,7 @@ public class Storage implements Listener {
             return false;
         }
         if (tempSellers.isEmpty()) {
+            SignShop.log("Loaded zero valid shops.",Level.INFO);
             return false;
         }
 
@@ -240,6 +244,7 @@ public class Storage implements Listener {
         }
 
         Bukkit.getPluginManager().registerEvents(this, SignShop.getInstance());
+        SignShop.log("Loaded " + shopCount() + " valid shops.", Level.INFO);
         return needSave;
     }
 

--- a/src/main/java/org/wargamer2010/signshop/configuration/Storage.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/Storage.java
@@ -181,7 +181,7 @@ public class Storage implements Listener {
         } catch(StorageException caughtex) {
             if(!caughtex.getWorld().isEmpty()) {
                 for(World temp : Bukkit.getServer().getWorlds()) {
-                    if(temp.getName().equalsIgnoreCase(caughtex.getWorld()) && temp.getLoadedChunks().length == 0) {
+                    if(temp.getName().equalsIgnoreCase(caughtex.getWorld()) && temp.getLoadedChunks().length == 0) { //TODO Option to short circuit this to prevent invalid shop removal
                         invalidShops.put(key, sellerSettings);
                         return true; // World might not be loaded yet
                     }

--- a/src/main/java/org/wargamer2010/signshop/player/SignShopPlayer.java
+++ b/src/main/java/org/wargamer2010/signshop/player/SignShopPlayer.java
@@ -148,7 +148,7 @@ public class SignShopPlayer {
         if (isOpRaw())
             return true;
         String fullperm = (perm.isEmpty() ? "SignShop.SuperAdmin" : "SignShop.SuperAdmin." + perm);
-        return SignShop.usePermissions() && Vault.getPermission().playerHas(world.toString(), getOfflinePlayer(), fullperm.toLowerCase());
+        return SignShop.usePermissions() && Vault.getPermission().playerHas(world.getName(), getOfflinePlayer(), fullperm.toLowerCase());
     }
 
     private boolean isOpRaw() {
@@ -188,7 +188,7 @@ public class SignShopPlayer {
             setOp(false);
         // Having Signshop.Superadmin while Permissions are in use should allow you to do everything with SignShop
         // And since the node is explicitly given to a player, the OPOverride setting is not relevant
-        if (SignShop.usePermissions() && Vault.getPermission().playerHas(world.toString(), getOfflinePlayer(), "signshop.superadmin")) {
+        if (SignShop.usePermissions() && Vault.getPermission().playerHas(world.getName(), getOfflinePlayer(), "signshop.superadmin")) {
             setOp(isOP);
             return true;
         }
@@ -197,7 +197,7 @@ public class SignShopPlayer {
         if (SignShop.usePermissions() && OPOverride && isOP)
             return true;
             // Using Permissions so check his permissions and restore his OP if he has it
-        else if (SignShop.usePermissions() && Vault.getPermission().playerHas(world.toString(), getOfflinePlayer(), perm.toLowerCase())) {
+        else if (SignShop.usePermissions() && Vault.getPermission().playerHas(world.getName(), getOfflinePlayer(), perm.toLowerCase())) {
             setOp(isOP);
             return true;
             // Not using Permissions but he is OP, so he's allowed

--- a/src/main/java/org/wargamer2010/signshop/util/itemUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/itemUtil.java
@@ -29,6 +29,7 @@ import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/** @noinspection deprecation*/ //TODO Remove deprecated calls
 public class itemUtil {
 
     private itemUtil() {
@@ -252,7 +253,7 @@ public class itemUtil {
         if(clickedSign(sign)) {
             Sign signblock = ((Sign) sign.getState());
             String[] sLines = signblock.getLines();
-            if(ChatColor.stripColor(sLines[0]).length() < 14) {
+            if(ChatColor.stripColor(sLines[0]).length() <= 14) {
                 signblock.setLine(0, (color + ChatColor.stripColor(sLines[0])));
                 signblock.update();
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -119,7 +119,9 @@ linkableMaterials:
   SPRUCE_SIGN: sign
   SPRUCE_WALL_SIGN: sign
   CRIMSON_SIGN: sign
+  CRIMSON_WALL_SIGN: sign
   WARPED_SIGN: sign
+  WARPED_WALL_SIGN: sign
   STEP: slab
   JUKEBOX: jukebox
   ACACIA_DOOR: door


### PR DESCRIPTION
Changes:
- Corrects the method used to check for perms when there are multiple world contexts. Closes #127 
- Adds some startup messages that clarify what SignShop is doing so users don't think the server is "hanging" when there are lots of shops to load.