### PR TITLE
Major overhaul of french translation

### DIFF
--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -1,8 +1,11 @@
+ 
 signs:
+  Réparer: Repair
+  Éliminer: Dispose
+  Désenchanter: Disenchant
   Acheter: Buy
   Vendre: Sell
   Donner: Donate
-  DonnerPaume: DonateHand
   Sous: Slot
   iAcheter: iBuy
   gVendre: gSell
@@ -10,29 +13,26 @@ signs:
   Nuit: Night
   Pluie: Rain
   CielClair: ClearSkies
-  AppareilSur: DeviceOn
-  AppareilVide: DeviceOff
+  AppareilOn: DeviceOn
+  AppareilOff: DeviceOff
   Toggle: Toggle
+  Basculer: Toggle
   Appareil: Device
-  Heal: Heal
-  Réparation: Repair
-  Éliminer: Dispose
+  Guérir: Heal
+  Jeter: Dispose
   AppareilItem: DeviceItem
   iSous: iSlot
-  Enchant: Enchant
+  Enchanter: Enchant
   iAcheterXP: iBuyXP
   iVendreXP: iSellXP
   iTroquer: iTrade
   TpToOwner: TpToOwner
   Classe: Class
-  Désenchant: Disenchant
   Commande: Command
   Partager: Share
   Restreint: Restricted
   iVendre: iSell
-  Sante: Heal
-  Achat: Buy
-  Vente: Sell
+  Santé: Heal
   Acces: Device
   AccesMagasins: Device
   AcheterXP: iBuyXP
@@ -41,196 +41,225 @@ signs:
   Slot: Slot
 messages:
   setup:
-    Buy: Vous avez mis !items en vente au prix de !price! cr\xe9dits
-    Sell: Vous avez mis en vente !items pour !price cr\xe9dits !
-    Donate: Vous avez configur\xe9 une boite de dons pour !items!
-    DonateHand: Vous avez configur\xe9 une bo\xeete de dons pour tous les  types d'\xe9l\xe9ments
-    Slot: Vous avez configur\xe9 une offre de !price cr\xe9dits pour cette boutique !items
-    iBuy: Vous avez cr\xe9\xe9 un achat illimit\xe9 de !price cr\xe9dits pour !items
-    iSell: Vous avez cr\xe9\xe9 une vente illimit\xe9 de !price cr\xe9dits pour !items cr\xe9dits
-    gBuy: Vous avez configur\xe9 un magasin vendant des !items pour !price cr\xe9dits (Notez que vous ne recevrez pas d'argent de cette boutique)
-    gSell: Vous avez configur\xe9 un achat fictifs !items pour !price cr\xe9dits (Notez que vous ne recevrez pas d'argent de cette boutique)
-    Day: Vous avez configur\xe9 un contr\xf4leur de jour pour un co\xfbt de !price cr\xe9dits
-    Night: Vous avez configur\xe9 un contr\xf4leur de nuit pour un co\xfbt de !price cr\xe9dits
-    Rain: Vous avez configur\xe9 un contr\xf4leur de pluie pour un co\xfbt de !price cr\xe9dits
-    ClearSkies: Vous avez configur\xe9 un contr\xf4leur de temps clair pour  co\xfbt de !price cr\xe9dits
-    DeviceOn: Vous avez configur\xe9 un dispositif activateur pour un co\xfbt de !price cr\xe9dits
-    DeviceOff: Vous avez configur\xe9 un dispositif d\xe9sactivateur pour un co\xfbt de !price cr\xe9dits
-    Toggle: Vous avez configur\xe9 un dispositif toggler que les co\xfbts de !price cr\xe9dits
-    Device: Vous avez configur\xe9 un dispositif temporaire activateur que les co\xfbts de !price cr\xe9dits
-    Heal: Vous avez configur\xe9 une station de gu\xe9rison que les co\xfbts de !price cr\xe9dits
-    Repair: Vous avez configur\xe9 une station de r\xe9paration que les co\xfbts de !price cr\xe9dits
-    Dispose: Vous avez configur\xe9 un signe Dispose
-    DeviceItem: Vous avez configur\xe9 un dispositif temporaire activateur !items que les co\xfbts!
-    iSlot: Vous avez configur\xe9 une offre de !price cr\xe9dits pour machine \xe0 sous infini !items
-    Enchant: Vous avez configur\xe9 un enchanteur qui co\xfbt !price et enchante avec !enchantements!
-    iSellXP: Vous avez mis une prime de !price pour !xp XP
-    iBuyXP: Vous avez mis !xp XP en vente au prix de !price
-    iTrade: Vous avez configur\xe9 une boutique de commerce qui co\xfbte !chest1 pour !chest2!
-    TpToOwner: Vous avez configur\xe9 une commande qui t\xe9l\xe9porte au propri\xe9taire pour le !price
-    Class: Vous avez configur\xe9 une boutique pour vendre un ensemble d'article pour !price cr\xe9dits
-    Disenchant: Vous avez configur\xe9 un panneau qui \xe9limine les enchantements pour !price cr\xe9dits
-    Command: Vous avez cr\xe9\xe9 un panneau qui ex\xe9cute des commandes pour !price cr\xe9dits
+    Buy: Vous avez mis !items en vente au prix de !price.
+    Sell: Vous achetez maintenant !items pour !price.
+    Donate: Vous avez configuré une boite de dons pour !items.
+    DonateHand: Vous avez configuré une boîte de dons pour tous les types d'éléments.
+    Slot: Vous avez configuré une machine à sous à !price offrant !items.
+    iBuy: Vous avez créé une vente illimitée de !items pour !price.
+    iSell: Vous avez créé un achat illimité de !items pour !price.
+    gBuy: Vous avez configuré un magasin fictif vendant des !items pour !price.
+      (Notez que vous ne recevrez pas d'argent de cette boutique)
+    gSell: Vous avez configuré un achat fictif de !items pour !price. (Notez
+      que vous ne recevrez pas d'argent de cette boutique)
+    Day: Vous avez configuré un contrôleur de jour pour un coût de !price.
+    Night: Vous avez configuré un contrôleur de nuit pour un coût de !price.
+    Rain: Vous avez configuré un contrôleur de pluie pour un coût de !price.
+    ClearSkies: Vous avez configuré un contrôleur de temps clair pour un coût de !price.
+    DeviceOn: Vous avez configuré un dispositif activateur pour un coût de !price.
+    DeviceOff: Vous avez configuré un dispositif désactivateur pour un coût de !price.
+    Toggle: Vous avez configuré un dispositif bascule pour un coût de !price.
+    Device: Vous avez configuré un dispositif activateur temporaire pour un coût de !price.
+    Heal: Vous avez configuré une station de guérison pour un coût de !price.
+    Repair: Vous avez configuré une station de réparation pour un coût de !price.
+    Dispose: Vous avez configuré un signe Jeter.
+    DeviceItem: Vous avez configuré un dispositif activateur temporaire pour un coût
+      de !items!
+    iSlot: Vous avez configuré une machine à sous illimitée offrant !items pour !price.
+    Enchant: Vous avez configuré un enchanteur qui coûte !price et enchante avec !enchantements.
+    iSellXP: Vous avez configuré un achat illimité de !xp au prix de !price.
+    iBuyXP: Vous avez configuré une vente illimitée de !xp XP au prix de !price.
+    iTrade: Vous avez configuré une boutique de commerce qui coûte !chest1 pour !chest2.
+    TpToOwner: Vous avez configuré une commande qui téléporte au propriétaire pour !price.
+    Class: Vous avez configuré une boutique pour vendre un ensemble d'articles pour !price.
+    Disenchant: Vous avez configuré un panneau qui élimine les enchantements pour !price.
+    Command: Vous avez créé un panneau qui exécute des commandes pour !price.
   confirm:
-    Buy: Acheter !items pour !price cr\xe9dits?
-    Sell: Vendre !items pour un montant de !price cr\xe9dits?
+    Disenchant: Retirer les enchantements de l'objet dans votre main pour !price?
+    Buy: Acheter !items pour !price?
+    Sell: Vendre !items pour un montant de !price?
     Donate: Donner !items?
     DonateHand: Donner !items?
-    Slot: Jouer \xe0 cette machine \xe0 sous pour !price cr\xe9dits?
-    Emplacement: Jouez \xe0 cette machine \xe0 sous pour le !price cr\xe9dits?
-    Redstone: Activer cet appareil pour !price cr\xe9dits?
-    iBuy: Acheter !items pour !price! cr\xe9dits?
-    iSell: Vendre des objets pour !price cr\xe9dits?
-    gBuy: Acheter !items pour !price! cr\xe9dits?
-    gSell: Vendre !items pour un montant de !price cr\xe9dits?
-    Day: Mettre le jour pour !price cr\xe9dits?
-    Night: Mettre la nuit pour !price cr\xe9dits?
-    Rain: Faire tomber la pluie pour !price cr\xe9dits?
-    ClearSkies: Eclaircir le ciel pour !price cr\xe9dits?
-    DeviceOn: Activer pour !price cr\xe9dits?
-    DeviceOff: D\xe9sactiver pour !price cr\xe9dits?
-    Toggle: Activer pour !price cr\xe9dits?
-    Device: Activer temporairement ce dispositif pour !price cr\xe9dits?
-    Heal: Vous gu\xe9rir pour !price cr\xe9dits?
-    Repair: R\xe9paration de l'objet tenu dans la main pour !price cr\xe9dits?
+    Slot: Jouer à cette machine à sous pour !price?
+    Redstone: Activer cet appareil pour !price?
+    iBuy: Acheter !items pour !price!?
+    iSell: Vendre des objets pour !price?
+    gBuy: Acheter !items pour !price!?
+    gSell: Vendre !items pour un montant de !price?
+    Day: Mettre le jour pour !price?
+    Night: Mettre la nuit pour !price?
+    Rain: Faire tomber la pluie pour !price?
+    ClearSkies: Eclaircir le ciel pour !price?
+    DeviceOn: Activer pour !price?
+    DeviceOff: Désactiver pour !price?
+    Toggle: Activer pour !price?
+    Device: Activer temporairement ce dispositif pour !price?
+    Heal: Vous guérir pour !price?
+    Repair: Réparation de l'objet tenu dans la main pour !price?
     Jeter: Jeter les !items?
     DeviceItem: Temporairement activer ce dispositif des !items?
-    iSlot: Jouez \xe0 cette machine \xe0 sous pour !price cr\xe9dits?
-    Enchant: Enchanter cet objet pour !price! cr\xe9dits?
-    iSellXP: Vendre !xp niveau(x) d'exp\xe9rience pour !price cr\xe9dits?
-    iBuyXP: Acheter !xp d'exp\xe9rience pour !price cr\xe9dits?
+    iSlot: Jouer à cette machine à sous pour !price?
+    Enchant: Enchanter cet objet pour !price!?
+    iSellXP: Vendre !xp niveau(x) d'expérience pour !price?
+    iBuyXP: Acheter !xp d'expérience pour !price?
     iTrade: Achat !chest2 avec !chest1?
-    TpToOwner: T\xe9l\xe9portation vers le propri\xe9taire pour !price c\xe9dits?
-    Class: Acheter cet ensemble d'\xe9l\xe9ment (!items) pour !price cr\xe9dits?
-    D\xe9senchanter: Retirer les enchantements de l'objet dans votre main pour le !price cr\xe9dits?
-    Command: Ex\xe9cutez les commandes sur ce signe pour le !price cr\xe9dits?
+    TpToOwner: Téléportation vers le propriétaire pour !price?
+    Class: Acheter cet ensemble d'élément (!items) pour !price?
+    Command: Exécute les commandes sur ce signe pour !price?
   transaction:
-    Buy: Vous avez achet\xe9 !items pour !price cr\xe9dits !
-    Sell: Vous avez vendu !items pour !price cr\xe9dits !
-    Donate: Vous avez donn\xe9 des objets!!
-    DonateHand: Vous avez donn\xe9 des objets!
-    Slot: Vous avez gagn\xe9 !items
-    Redstone: Dispositif activ\xe9 pour !price cr\xe9dits
-    iBuy: Vous avez achet\xe9 !items pour !price cr\xe9dits!
-    iSell: Vous avez vendu !items pour !price cr\xe9dits!
-    gBuy: Vous avez achet\xe9 !items pour !price cr\xe9dits!
-    gSell: Vous avez vendu !items pour !price cr\xe9dits!
-    Day: Vous avez fait lever le soleil pour !price cr\xe9dits
-    Night: Vous avez fait coucher le soleil pour !price cr\xe9dits
-    Rain: Vous avez fait pleuvoir pour !price cr\xe9dits
-    ClearSkies: Vous avez fait s'\xe9claircir le ciel pour !price cr\xe9dits
-    DeviceOn: Vous avez activ\xe9 ce dispositif pour !price cr\xe9dits
-    DeviceOff: Vous avez d\xe9sactiv\xe9 ce dispositif pour !price cr\xe9dits
-    Toggle: Vous bascul\xe9 cet appareil pour !price cr\xe9dits
-    Device: Vous avez temporairement activ\xe9 ce dispositif pour !price cr\xe9dits
-    Heal: Vous vous \xeates gu\xe9ri pour !price cr\xe9dits
-    R\xe9paration: Vous avez r\xe9par\xe9 un \xe9l\xe9ment pour !price cr\xe9dits
-    Dispose: Vous avez dispos\xe9 d'\xe9l\xe9ments!
-    DeviceItem: Vous avez temporairement activ\xe9 le dispositif des !items
-    iSlot: Vous avez gagn\xe9 !items
-    Enchant: Vous avez enchant\xe9 votre objet pour !price cr\xe9dits!
-    iSellXP: Vous avez vendu !xp d'exp\xe9rience pour !price cr\xe9dits
-    iBuyXP: Vous avez achet\xe9 !xp d'exp\xe9rience pour !price cr\xe9\dits
-    iTrade: \xc3\u2030chang\xe9 !chest1 pour !chest2!
-    TpToOwner: Vous t\xe9l\xe9porte au !owner pour le !price cr\xe9dits
-    Class: Vous avez achet\xe9 l'ensemble contenant les articles !items pour !price cr\xe9dits
-    Disenchant: Vous avez retir\xe9 les enchantements sur l'objet dans votre main pour !price cr\xe9dits
-    Command: Vous ex\xe9cutez les commandes du panneau pour !price cr\xe9\dits
+    Repair: Vous avez réparé un élément pour !price
+    Buy: Vous avez acheté !items pour !price!
+    Sell: Vous avez vendu !items pour !price!
+    Donate: Vous avez donné des objets!
+    DonateHand: Vous avez donné des objets!
+    Slot: Vous avez gagné !items!
+    Redstone: Dispositif activé pour !price!
+    iBuy: Vous avez acheté !items pour !price!
+    iSell: Vous avez vendu !items pour !price!
+    gBuy: Vous avez acheté !items pour !price!
+    gSell: Vous avez vendu !items pour !price!
+    Day: Vous avez fait lever le soleil pour !price!
+    Night: Vous avez fait coucher le soleil pour !price!
+    Rain: Vous avez fait pleuvoir pour !price!
+    ClearSkies: Vous avez fait s'éclaircir le ciel pour !price!
+    DeviceOn: Vous avez activé ce dispositif pour !price!
+    DeviceOff: Vous avez désactivé ce dispositif pour !price!
+    Toggle: Vous avez basculé cet appareil pour !price!
+    Device: Vous avez temporairement activé ce dispositif pour !price!
+    Heal: Vous vous êtes guéri pour !price!
+    Dispose: Vous avez jeté des éléments!
+    DeviceItem: Vous avez temporairement activé le dispositif des !items !
+    iSlot: Vous avez gagné !items !
+    Enchant: Vous avez enchanté votre objet pour !price!
+    iSellXP: Vous avez vendu !xp points d'expérience pour !price!
+    iBuyXP: Vous avez acheté !xp points d'expérience pour !price!
+    iTrade: Vous avez échangé !chest1 pour !chest2!
+    TpToOwner: Vous serez téléporté au propriétaire !owner pour !price!
+    Class: Vous avez acheté l'ensemble contenant les articles !items pour !price!
+    Disenchant: Vous avez retiré les enchantements sur l'objet dans votre main pour !price!
+    Command: Vous exécutez les commandes du panneau pour !price!
   transaction_owner:
-    Buy: \!customer vous a achet\xe9 !items pour !price cr\xe9dits!
-    Sell: \!customer vous a vendu des !items pour !price cr\xe9dits!
+    Heal: \!customer s'est guéri à votre station pour !price!
+    Repair: \!customer a réparé un article à votre station pour !price!
+    Buy: \!customer vous a acheté !items pour !price!
+    Sell: \!customer vous a vendu des !items pour !price!
     Donate: \!customer vous a fait don d'!items!
-    DonateHand: \!customer vous a fait don d'!items!
-    Slot: \!customer a jou\xe9 sur une machine \xe0 sous pour !price cr\xe9dits et gagn\xe9 !items!
-    Emplacement: \!customer a jou\xe9 sur une machine \xe0 sous pour !price cr\xe9dits et a remport\xe9 !items
-    Redstone: \!customer a activ\xe9 votre machine \xe0 redstone pour !price cr\xe9dits
+    DonateHand: \!customer vous a fait don de !items!
+    Slot: \!customer a joué sur une machine à sous pour !price et a remporté !items!
+    Redstone: \!customer a activé votre machine à redstone pour !price!
     iBuy: ''
     iSell: ''
-    gBuy: \!customer a achet\xe9 des !items de votre boutique fant\xf4me!
-    gSell: \!customer a vendu des !items \xe0 votre magasin fant\xf4me!
-    Day: \!customer a mis le jour pour !price cr\xe9dits
-    Night: \!customer a mis la nuit pour !price cr\xe9dits
-    Rain: \!customer a fait pleuvoir pour !price cr\xe9dits
-    ClearSkies: \!customer \xe0 \xe9claircie le ciel pour le !price cr\xe9dits
-    DeviceOn: \!customer a activ\xe9 votre appareil pour !price cr\xe9dits
-    DeviceOff: \!customer a d\xe9sactiv\xe9 votre appareil pour !price cr\xe9dits
-    Basculez: \!customer a bascul\xe9 votre appareil pour !price cr\xe9dits
-    Device: \!customer a activ\xe9 temporairement votre appareil pour !price cr\xe9dits
-    Gu\xe9rir: \!customer s'est gu\xe9ri \xe0 votre station pour !price cr\xe9dits
-    R\xe9paration: \!customer a r\xe9par\xe9 un article \xe0 votre station pour !price cr\xe9dits
+    gBuy: \!customer a acheté des !items de votre boutique fictive!
+    gSell: \!customer a vendu des !items à votre magasin fictive!
+    Day: \!customer a mis le jour pour !price!
+    Night: \!customer a mis la nuit pour !price!
+    Rain: \!customer a fait pleuvoir pour !price!
+    ClearSkies: \!customer a éclairci le ciel pour !price!
+    DeviceOn: \!customer a activé votre appareil pour !price!
+    DeviceOff: \!customer a désactivé votre appareil pour !price!
+    Toggle: \!customer a basculé votre appareil pour !price!
+    Device: \!customer a activé temporairement votre appareil pour !price!
     Dispose: ''
-    DeviceItem: \!customer a activ\xe9 temporairement votre appareil des !items
+    DeviceItem: \!customer a activé temporairement votre appareil des !items!
     iSlot: ''
-    Enchant: \!customer a enchant\xe9 son article avec des enchantements pour !price cr\xe9dits!
+    Enchant: \!customer a enchanté son article avec des enchantements pour !price!
     iSellXP: ''
     iBuyXP: ''
     iTrade: ''
-    TpToOwner: \!customer s'est t\xe9l\xe9port\xe9 jusqu'\xe0 vous pour !price cr\xe9dits
+    TpToOwner: \!customer s'est téléporté jusqu'à vous pour !price!
     Class: ''
     Disenchant: ''
     Command: ''
 errors:
-  no_permission: Vous n'avez pas la permission de cr\xe9er ce signe!
+  no_permission: Vous n'avez pas la permission de créer ce signe!
   no_permission_use: Vous n'avez pas la permission d'utiliser ce signe!
-  invalid_operation: Le signe sur lequel vous avez cliqu\xe9 n'est pas valide!
+  invalid_operation: Le signe sur lequel vous avez cliqué n'est pas valide!
   chest_empty: Le magasin est vide!
   chest_missing: Vous devez lier au moins un coffre avec ce magasin!
   lever_missing: Vous devez lier au moins un levier pour ce magasin!
-  no_player_money: Vous n'avez pas assez d'argent pour payer ce prix (!price cr\xe9dits)!
-  no_shop_money: Le magasin n'a pas la somme de !price cr\xe9dits pour vous payer!
-  out_of_business: Cette boutique semble avoir disparu du march\xe9!
+  no_player_money: Vous n'avez pas assez d'argent pour effectuer cet achat (!price)!
+  no_shop_money: Le magasin n'a pas la somme de !price pour vous payer!
+  out_of_business: Cette boutique semble avoir disparu du marché!
   out_of_stock: Cette boutique est en rupture de stock!
-  overstocked: Cette boutique est surcharg\xe9, demandez au propri\xe9taire de vider le stock!
-  player_doesnt_have_items: Vous n'avez pas les !items
-  no_item_in_hand: Vous devez tenir un objet en main pour que le magasin puisse le prendre.!
+  overstocked: Cette boutique est surchargée, demandez au propriétaire de vider le
+    stock!
+  player_doesnt_have_items: Vous n'avez pas les !items!
+  no_item_in_hand: Vous devez tenir un objet en main pour que le magasin puisse le
+    prendre!
   player_overstocked: Votre inventaire est trop plein!
-  sign_location_stored: Connexion emplacement m\xe9moris\xe9!
-  made_day: \!customer a fait appara\xeetre le jour!
-  made_night: \!customer a fait appara\xeetre la nuit!
+  sign_location_stored: Emplacement du signe mémorisé!
+  made_day: \!customer a fait apparaître le jour!
+  made_night: \!customer a fait apparaître la nuit!
   made_rain: \!customer a fait pleuvoir!
-  made_clear_skies: \!customer a \xe9claici le ciel !
-  already_on: Le p\xe9riph\xe9rique est d\xe9j\xe0 activ\xe9.
-  already_off: Le p\xe9riph\xe9rique est d\xe9j\xe0 \xe9teint.
-  link_notallowed: Vous n'\xeates pas autoris\xe9 \xe0 \xe9ffectuer le lien!
-  item_already_repair: C'est article est d\xe9j\xe0 enti\xc3\xa8rement r\xe9par\xe9!
-  already_raining: Il est d\xe9j\xe0 prise d'assaut!
-  already_clear_skies: Le ciel est d\xe9j\xe0 clair!
-  already_full_health: Votre sant\xe9 est d\xe9j\xe0 bien rempli!
-  saving: Enregistrement magasins ...
-  saved: Magasins sauv\xe9!
-  shop_removed: Suppression d'une boutique invalide! Il devrait \xeatre en '!world' (!x,!y, !z).
-  invalid_item_to_repair: Cet objet ne peut pas \xeatre r\xe9par\xe9!
-  no_item_to_repair: Vous devez tenir en main l'objet que vous voulez r\xe9parer! ;-)
-  backup_fail: \xe9chec de la sauvegarde de stockage!
-  too_far: La distance entre le signe et le coffre est trop grand. Le maximum est de !Max.
-  too_many_shops: Vous avez atteint la quantit\xe9 maximale de magasins autoris\xe9s. Le maximum est de !Max.
-  enchanted_not_allowed: Vous n'\xeates pas autoris\xe9 \xe0 r\xe9parer des objets enchant\xe9s.
-  enchantment_missing: Au moins un objet enchant\xe9 est n\xe9cessaire, mettez en un dans le coffre(s)!
+  made_clear_skies: \!customer a éclaici le ciel!
+  already_on: Le périphérique est déjà activé!
+  already_off: Le périphérique est déjà éteint!
+  link_notallowed: Vous n'êtes pas autorisé à effectuer le lien!
+  item_already_repair: C'est article est déjà entièrement réparé!
+  already_raining: Il pleut déjà!
+  already_clear_skies: Le ciel est déjà clair!
+  already_full_health: Votre santé est déjà bien remplie!
+  saving: Enregistrement des magasins ...
+  saved: Magasins sauvegardés!
+  shop_removed: Suppression d'une boutique invalide! Il devrait être en '!world' (!x,!y,
+    !z).
+  invalid_item_to_repair: Cet objet ne peut pas être réparé!
+  no_item_to_repair: Vous devez tenir en main l'objet que vous voulez réparer!
+  backup_fail: Échec de la sauvegarde de stockage!
+  too_far: La distance entre le signe et le coffre est trop grande. Le maximum est
+    de !Max!
+  too_many_shops: Vous avez atteint la quantité maximale de magasins autorisés. Le
+    maximum est de !Max!
+  enchanted_not_allowed: Vous n'êtes pas autorisé à réparer des objets enchantés!
+  enchantment_missing: Au moins un objet enchanté est nécessaire, mettez en un dans
+    le(s) coffre(s)!
   item_not_enchantable: L'article dans votre main n'est pas enchantable!
-  no_player_xp: Vous n'avez pas assez d'exp\xe9rience pour vendre (!xp)!
-  no_item_to_disenchant: Vous devez tenir en main l'objet que vous voulez d\xe9senchanter!
-  nothing_to_disenchant: Cet objet ne peut pas \xeatre d\xe9senchant\xe9!
-  multiworld_not_allowed: Multiworld magasins ne sont pas autoris\xe9s sur ce serveur!
-  no_permit_owner: Le propri\xe9taire de cette boutique n'est plus autoris\xe9!
-  need_permit: Il faut \xeatre autoris\xe9 pour mettre en place cette boutique!
-  villager_trading_disabled: Les \xe9changes avec les villageois ne sont pas autos\xe9s sur ce serveur!
-  not_allowed_to_link_sharesigns: Vous n'\xeates pas autoris\xe9 \xe0 lier les signes partag\xe9s \xe0 ce magasin!
-  no_shop_linked_to_sharesign: Ce signe Partagez n'a pas \xe9t\xe9 li\xe9 \xe0 tous les magasins.
-  share_sign_splits_profit: Ce signe se partage les b\xe9n\xe9fices entre les !profits pour la boutique (s) \xe0 !profitshops!
-  registered_share_sign: Inscrit le signe Partager, s'il vous pla\xeet cliquer sur le signe magasin le plus proche.
-  unlinked_share_sign: Signe Partager D\xe9li\xe9 de la boutique.
-  linked_share_sign: Signe Partager avec succ\xc3\xa8s li\xe9s \xe0 la boutique.
-  not_allowed_to_link_restrictedsigns: Vous n'\xeates pas autoris\xe9 \xe0 lier signes affect\xe9s \xe0 ce magasin!
-  no_shop_linked_to_restrictedsign: Ce signe restreint n'a pas \xe9t\xe9\ li\xe9 \xe0 tous les magasins.
-  registered_restricted_sign: Inscrit le signe restreint, s'il vous pla\xeet cliquer sur le signe magasin le plus proche.
-  unlinked_restricted_sign: Le signe restreint \xe0 \xe9t\xe9 d\xe9li\xe9.
-  linked_restricted_sign: succ\xc3\xa8s li\xe9s signe R\xe9serv\xe9 \xe0 la boutique.
-  restricted_sign_restricts: Ce signe restreint limite l'utilisation de la boutique(s) \xe0 restrictedshops!
-  towny_insufficient_funds: Le manque de fonds dans le compte de boutique!
-  towny_owner_not_mayor_or_assistant: Le propri\xe9taire de la boutique n'est pas un maire ou d'adjoint d'une ville.
-  towny_owner_not_belong_to_town: Le propri\xe9taire du magasin ne devrait pas appartenir \xe0 une ville.
-  towny_bank_withdrawls_not_allowed: La configuration actuelle ne permet pas Towny retraits bancaires!
-  restricted_from_using: Vous \xeates limit\xe9 dans l'utilisation de ce magasin!
-  restricted_but_owner: Vous n'\xeates pas limit\xe9 \xe0 l'utilisation de cette boutique car vous \xeates le propri\xe9taire.
-  item_on_blacklist: L'article !blacklisted_item est sur LISTE NOIRE et ne peut donc pas \xeatre utilis\xe9.
-  item_on_blacklist_but_op: L'article !blacklisted_item est sur LISTE NOIRE, mais vous \xeates OP.
+  no_player_xp: Vous n'avez pas assez d'expérience pour vendre (!xp)!
+  no_item_to_disenchant: Vous devez tenir en main l'objet que vous voulez désenchanter!
+  nothing_to_disenchant: Cet objet ne peut pas être désenchanté!
+  multiworld_not_allowed: Les magasins Multiworld ne sont pas autorisés sur ce serveur!
+  no_permit_owner: Le propriétaire de cette boutique n'est plus autorisé!
+  need_permit: Il faut être autorisé pour mettre en place cette boutique!
+  villager_trading_disabled: Les échanges avec les villageois ne sont pas autorisés
+    sur ce serveur!
+  not_allowed_to_link_sharesigns: Vous n'êtes pas autorisé à lier les signes partagés
+    à ce magasin!
+  no_shop_linked_to_sharesign: Ce signe Partagez n'a pas été lié à tous les magasins!
+  share_sign_splits_profit: Ce signe se partage les bénéfices entre les !profits pour
+    la boutique (s) à !profitshops!
+  registered_share_sign: Pour inscrire le signe Partager, cliquer sur le signe magasin
+    le plus proche!
+  unlinked_share_sign: Signe Partager délié de la boutique!
+  linked_share_sign: Signe Partager lié à la boutique avec succès!
+  not_allowed_to_link_restrictedsigns: Vous n'êtes pas autorisé à lier signes affectés
+    à ce magasin!
+  no_shop_linked_to_restrictedsign: Ce signe restreint n'a pas été lié à tous les
+    magasins!
+  registered_restricted_sign: Inscrit le signe restreint, s'il vous plaît cliquer
+    sur le signe magasin le plus proche!
+  unlinked_restricted_sign: Le signe restreint à été délié!
+  linked_restricted_sign: Signe Restreint lié à la boutique avec succès!
+  restricted_sign_restricts: Ce signe Restreint limite l'utilisation de la boutique(s)
+    à !restrictedshops!
+  towny_insufficient_funds: Manque de fonds dans le compte de la boutique!
+  towny_owner_not_mayor_or_assistant: Le propriétaire de la boutique n'est pas maire
+    ou adjoint d'une ville!
+  towny_owner_not_belong_to_town: Le propriétaire du magasin ne devrait pas appartenir
+    à une ville!
+  towny_bank_withdrawls_not_allowed: La configuration actuelle de Towny ne permet
+    pas des retraits bancaires!
+  restricted_from_using: Vous êtes limité dans l'utilisation de ce magasin!
+  restricted_but_owner: Vous n'êtes pas limité à l'utilisation de cette boutique car
+    vous êtes le propriétaire!
+  item_on_blacklist: L'article !blacklisted_item est sur LISTE NOIRE et ne peut donc
+    pas être utilisé!
+  item_on_blacklist_but_op: L'article !blacklisted_item est sur LISTE NOIRE, mais
+    vous êtes OP!
+  shop_contains: Ce magasin contient !shopinventory @ !items pour !price!
+  removed_location: Emplacement supprimé!
+  stored_location: Emplacement de !block enregistré!
+  stored_location_containable: Emplacement de !block contenant !items enregistré!
+  failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur
+    ci-haut!
+  price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire
+    d'économie Essentials. Il est donc variable.

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -331,55 +331,54 @@ errors:
   item_not_on_whitelist: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist) et ne peut donc pas être utilisé dans les boutiques.
   item_not_on_whitelist_but_op: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist), mais vous êtes OP!
 
-  #TODO / A FAIRE
-  block_is_protected: This block is protected, you are not allowed to interact with it.
-  updated_shop: The shop has been succesfully updated.
+  block_is_protected: Ce bloc est prorégé, vous n'êtes pas autorisé à interagir avec celui-ci.
+  updated_shop: La boutique a été mise à jour avec succès.
   failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur ci-haut!
   price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire d'économie Essentials. Il peut donc varier.
-  only_one_time: You can only use this shop once.
-  nothing_to_reset_ontime: You are already allowed to use !param signs one time. So there's nothing to reset.
+  only_one_time: Vous ne pouvez utiliser cette boutique qu'une seule fois.
+  nothing_to_reset_ontime: Vous êtes déjà autorisé à utiliser les panneaux !param une fois. Il n'y a donc rien à réinitialiser.
   shop_on_cooldown: Ce magasin termine une transaction. Veuillez patienter !cooldownleft secondes.
-  damaged_items_shop_homogeneous: A shop accepting damaged items can only deal in one type of item! Damaged items are not accepted until the shop is fixed.
-  use_item_to_destroy_shop: This shop is protected and can only be destroyed with a(n) !destroymaterial.
-  no_items_defined_for_shop: There are no items defined for this shop, can not complete the operation.
-  notifications_shop_built: \!player just created a(n) !signtype sign at (!x, !y, !z)
+  damaged_items_shop_homogeneous: Une boutique acceptant des items endommagés ne peut accepter qu'un seul type d'item! Les items endommagés ne sont pas acceptés tant que la boutique n'est pas réparée.
+  use_item_to_destroy_shop: Cette boutique est protégée et peut seulement être détruite avec (n) !destroymaterial.
+  no_items_defined_for_shop: Il n'y a aucun item défini pour cette boutique, l'opération ne peut être complétée.
+  notifications_shop_built: \!player vient de créer (n) panneau !signtype  à (!x, !y, !z)
   shop_contains: Ce magasin contient !shopinventory @ !items pour !price!
-  not_allowed_to_link_banksigns: You are not allowed to link Bank signs to this shop!
-  no_shop_linked_to_banksign: This Bank sign has not been linked to any shops.
-  bank_sign_linked_to_banks: This Bank sign communicates with bank called !bank in the name of the shops at !bankshops
-  registered_bank_sign: Registered a Bank sign, please click the Shop sign next.
-  unlinked_bank_sign: Unlinked Bank sign from Shop.
-  linked_bank_sign: Succesfully linked Bank sign to Shop.
-  not_allowed_to_use_bank: You are not the owner or a member of !bank Bank so the related Bank sign will be ignored.
-  no_bank_available: There is no Bank available to process the request, please contact the shop owner.
-  no_bank_support: The Economy plugin installed on this server does not support Banks.
-  repeated_x_times: (repeated !times times)
+  not_allowed_to_link_banksigns: Vous n'êtes pas autorisé à lier des panneaux Banque à cette boutique!
+  no_shop_linked_to_banksign: Ce panneau Banque n'est lié à aucune boutique!
+  bank_sign_linked_to_banks: Ce panneau Banque communique avec la banque nommée !bank au nom bes boutiques à !bankshops
+  registered_bank_sign: Panneau Banque enregistré. Veuillez maintenant cliquer sur le panneau de la boutique.
+  unlinked_bank_sign: Panneau Banque délié de la boutique.Unlinked Bank sign from Shop.
+  linked_bank_sign: Panneau Banque lié avec succès à la boutique.
+  not_allowed_to_use_bank: Vous n'êtes pas propriétaire ou membre de la banque !bank. Le panneau Banque qui y est lié sera ignoré.
+  no_bank_available: Aucune banque n'est disponible pour traiter votre requête, veuillez contacter le propriétaire de la boutique.
+  no_bank_support: Le plugin d'Économie installé sur ce serveur ne supporte pas les banques.
+  repeated_x_times: (répété !times fois)
   removed_location: Emplacement supprimé!
   stored_location: Emplacement de !block enregistré!
   stored_location_containable: Emplacement de !block contenant !items enregistré!
-  region_does_not_allow_shops: Shops are not allowed within this region. Please move the sign somewhere else.
-  region_allow_shops_but_op: This shop is not in a region with the "allow-shop" flag set to true but you are OP.
-  region_allow_shops_but_perm: This shop is not in a region with the "allow-shop" flag set to true but you have the bypass permission node.
-  towny_shop_plot_not_allowed: This shop is not on a shop plot, please move it.
-  towny_shop_plot_not_allowed_but_op: This shop is not on a shop plot but you are OP.
-  towny_shop_plot_not_allowed_but_perm: This shop is not on a shop plot but you have the bypass permission node.
-  deselected_hanging: You have deselected a Hanging item.
-  selected_hanging: You have selected a Hanging item.
-  itemframe_unlinked: ItemFrame has been successfully unlinked.
-  itemframe_linked: ItemFrame has been successfully linked.
-  itemframe_already_linked: This ItemFrame is already linked to another shop.
-  shop_is_now_protected: Your chest(s) have been locked automatically.
-  not_allowed_to_rotate_frame: You are not allowed to rotate this ItemFrame.
-  no_permission_plugin: No permission plugin could be found.
-  missing_promote_group: Please write the Permission group to promote to on the second line.
-  promote_group_does_not_exist: The Permission group on the second line does not exist.
-  not_in_permission_group: You aren't in a permission group yet.
-  already_in_promote_group: You are already in the group.
-  could_not_remove_primary_group: Could not remove you from your primary group
-  could_not_promote: Could not promote you.
-  must_be_op_to_run: You do not have the right permission to run this command, it is for OPs only.
-  not_allowed_on_plot: You are not allowed to link this on this plot!
-  not_allowed_on_plot_but_op: You are not allowed to link this on this plot, but you are OP.
-  exceeded_max_amount_of_chests_per_shop: You have exceeded the maximum amount of chests (!maxAmountOfChests) that can be linked to a single shop. Please unlink one or more before continuing.
-  this_shop_exceeded_max_amount_of_chests: Shop in world '!world' at (!x, !y, !z) exceeds the maximum amount of chests per shop!
-  could_not_complete_operation: Could not complete operation, contact your System Administrator and checks the logs.
+  region_does_not_allow_shops: Les boutiques ne sont pas autorisées dans cette région. Veuillez déplacer votre panneau à un autre endroit.
+  region_allow_shops_but_op: Cette boutique n'est pas dans une région ayant le flag "allow-shop" défini à "true", mais vous êtes OP.
+  region_allow_shops_but_perm: Cette boutique n'est pas dans une région ayant le flag "allow-shop" défini à "true", mais vous avez la permission "bypass".
+  towny_shop_plot_not_allowed: Cette boutique n'est pas sur un terrain pour boutiques (shop plot), veuillez la déplacer.
+  towny_shop_plot_not_allowed_but_op: Cette boutique n'est pas sur un terrain pour boutiques (shop plot), mais vous êtes OP.
+  towny_shop_plot_not_allowed_but_perm: Cette boutique n'est pas sur un terrain pour boutiques (shop plot), mais vous avez la permission "bypass".
+  deselected_hanging: Vous avez désélectionné un item pouvant être accroché.
+  selected_hanging: Vous avez sélectionné un item pouvant être accroché.
+  itemframe_unlinked: Le cadre a été délié de la boutique.
+  itemframe_linked: Le cadre a été lié à la boutique.
+  itemframe_already_linked: Ce cadre est déjà lié à une boutique.
+  shop_is_now_protected: Vos coffres ont été verrouillés automatiquement.
+  not_allowed_to_rotate_frame: Vous n'êtes pas autorisé à faire pivoter l'objet sur ce cadre.
+  no_permission_plugin: Aucun plugin de permissions n'a été trouvé..
+  missing_promote_group: Veuillez inscrire le group de permission à donner en promotion sur le seconde ligne.
+  promote_group_does_not_exist: Le groupe de permission inscrit sur la deuxième ligne n'existe pas.
+  not_in_permission_group: Vous n'êtes dans aucun groupe de permission pour le moment.
+  already_in_promote_group: Vous êtes déjà dans le groupe de promotion.
+  could_not_remove_primary_group: Impossible de vous retirer de votre groupe primaire.
+  could_not_promote: Impossible de vous donner la promotion.
+  must_be_op_to_run: Vous n'avez pas la permission d'exécuter cette commande, elle est destinée seulement aux OP.
+  not_allowed_on_plot: Vous n'êtes pas autorisé à lier une boutique sur ce terrain!
+  not_allowed_on_plot_but_op: Vous n'êtes pas autorisé à lier une boutique sur ce terrain, mais vous êtes OP!
+  exceeded_max_amount_of_chests_per_shop: Vous avez dépassé le nombre maximal de coffres (!maxAmountOfChests) qui peuvent être liés à une seule boutique. Veuillez délier un ou plusieurs coffres avant de poursuivre.
+  this_shop_exceeded_max_amount_of_chests: La boutique dans le monde '!world' à la position (!x, !y, !z) dépasse le nombre maximal de coffres alloués par boutique.
+  could_not_complete_operation: Impossible de compléter l'opération, veuillez contacter un administrateur et consultez les journaux d'événements.

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -82,9 +82,9 @@ messages:
     DonateHand: Donner !items?
     Slot: Jouer à cette machine à sous pour !price?
     Redstone: Activer cet appareil pour !price?
-    iBuy: Acheter !items pour !price!?
+    iBuy: Acheter !items pour !price?
     iSell: Vendre des objets pour !price?
-    gBuy: Acheter !items pour !price!?
+    gBuy: Acheter !items pour !price?
     gSell: Vendre !items pour un montant de !price?
     Day: Mettre le jour pour !price?
     Night: Mettre la nuit pour !price?
@@ -99,7 +99,7 @@ messages:
     Jeter: Jeter les !items?
     DeviceItem: Temporairement activer ce dispositif des !items?
     iSlot: Jouer à cette machine à sous pour !price?
-    Enchant: Enchanter cet objet pour !price!?
+    Enchant: Enchanter cet objet pour !price?
     iSellXP: Vendre !xp niveau(x) d'expérience pour !price?
     iBuyXP: Acheter !xp d'expérience pour !price?
     iTrade: Achat !chest2 avec !chest1?

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -1,4 +1,7 @@
- 
+# Ceci est une liste de mots-clé en français à inscrire sur les panneaux,
+# suivis de la fonctionnalité correspondante en anglais.
+
+
 signs:
   Réparer: Repair
   Éliminer: Dispose
@@ -39,7 +42,11 @@ signs:
   VendreXP: iSellXP
   DonnerMain: DonateHand
   Slot: Slot
+
+
+# Messages apparaissant quand les joueurs interagissent avec les panneaux
 messages:
+  # Messages apparaissant quand vous créez un magasin en cliquant sur un panneau avec le matériel de laison (Redstone par défaut)
   setup:
     Buy: Vous avez mis !items en vente au prix de !price.
     Sell: Vous achetez maintenant !items pour !price.
@@ -60,25 +67,34 @@ messages:
     Device: Vous avez configuré un dispositif activateur temporaire pour un coût de !price.
     Heal: Vous avez configuré une station de guérison pour un coût de !price.
     Repair: Vous avez configuré une station de réparation pour un coût de !price.
-    Dispose: Vous avez configuré un signe Jeter.
-    DeviceItem: Vous avez configuré un dispositif activateur temporaire pour un coût de !items!
+    Dispose: Vous avez configuré un panneau Jeter.
+    DeviceItem: Vous avez configuré un dispositif activateur temporaire pour un coût de !items.
     iSlot: Vous avez configuré une machine à sous illimitée offrant !items pour !price.
     Enchant: Vous avez configuré un enchanteur qui coûte !price et enchante avec !enchantements.
     iSellXP: Vous avez configuré un achat illimité de !xp au prix de !price.
     iBuyXP: Vous avez configuré une vente illimitée de !xp XP au prix de !price.
-    iTrade: Vous avez configuré une boutique de commerce qui coûte !chest1 pour !chest2.
+    iTrade: Vous avez configuré une boutique d'échange illimitée qui coûte !chest1 pour !chest2.
+    Trade: Vous avez configuré une boutique d'échange qui coûte !chest1 pour !chest2.
     TpToOwner: Vous avez configuré une commande qui téléporte au propriétaire pour !price.
     Class: Vous avez configuré une boutique pour vendre un ensemble d'articles pour !price.
     Disenchant: Vous avez configuré un panneau qui élimine les enchantements pour !price.
-    Command: Vous avez créé un panneau qui exécute des commandes pour !price.
+    Command: Vous avez configuré un panneau qui exécute des commandes pour !price.
+    UserCommand: Vous avez configuré un panneau qui exécute des commandes comme si un jour les avait tappées dans le chat pour !price.
+    Jukebox: Vous avez configuré un Jukebox qui joue les disques du coffre pour !price.
+    Kit: Vous avez configuré un kit d'items à usage unique (!items) pour !price.
+    ResetKit: Vous avez configuré un panneau qui réinitialise les panneaux !param.
+    iXPBuy: Vous avez mis en vente !items au prix de !xp points XP.
+    iXPSell: Vous avez configuré une vente illimitée de !items pour !xp points XP.
+    Promote: Vous avez configuré un panneau de promotion qui promouvoit l'utilisateur au groupe !promoteto.
+    TCommand: Vous avez configuré un panneau qui exécute les commandes sur ce panneau après 10 secondes pour !price.
+  
+  # Messages affichés quand vous faites un clic gauche sur un panneau
   confirm:
-    Disenchant: Retirer les enchantements de l'objet dans votre main pour !price?
     Buy: Acheter !items pour !price?
     Sell: Vendre !items pour un montant de !price?
     Donate: Donner !items?
     DonateHand: Donner !items?
     Slot: Jouer à cette machine à sous pour !price?
-    Redstone: Activer cet appareil pour !price?
     iBuy: Acheter !items pour !price?
     iSell: Vendre des objets pour !price?
     gBuy: Acheter !items pour !price?
@@ -93,7 +109,7 @@ messages:
     Device: Activer temporairement ce dispositif pour !price?
     Heal: Vous guérir pour !price?
     Repair: Réparation de l'objet tenu dans la main pour !price?
-    Jeter: Jeter les !items?
+    Dispose: Jeter les !items?
     DeviceItem: Temporairement activer ce dispositif des !items?
     iSlot: Jouer à cette machine à sous pour !price?
     Enchant: Enchanter cet objet pour !price?
@@ -102,15 +118,24 @@ messages:
     iTrade: Achat !chest2 avec !chest1?
     TpToOwner: Téléportation vers le propriétaire pour !price?
     Class: Acheter cet ensemble d'élément (!items) pour !price?
-    Command: Exécute les commandes sur ce signe pour !price?
+    Disenchant: Retirer les enchantements de l'objet dans votre main pour !price?
+    Command: Exécute les commandes sur ce panneau pour !price?
+    UserCommand: Exécuter les commandes sur se panneau pour price?
+    Jukebox: Jouer un disque pour !price?
+    Kit: Obtenir ce kit (!items) une fois pour !price?
+    ResetKit: Réinitialiser vos panneaux !param pour !price?
+    iXPBuy: Acheter !items pour !xp points XP?
+    iXPSell: Vendre !items pour !xp points XP?
+    Promote: Recevoir une promotion de !permgroup à !promoteto?
+    TCommand: Exécute les commandes sur ce panneau dans 10 secondes pour !price?
+
+  # Messages affichés après avoir complété une transaction
   transaction:
-    Repair: Vous avez réparé un élément pour !price
     Buy: Vous avez acheté !items pour !price!
     Sell: Vous avez vendu !items pour !price!
     Donate: Vous avez donné des objets!
     DonateHand: Vous avez donné des objets!
     Slot: Vous avez gagné !items!
-    Redstone: Dispositif activé pour !price!
     iBuy: Vous avez acheté !items pour !price!
     iSell: Vous avez vendu !items pour !price!
     gBuy: Vous avez acheté !items pour !price!
@@ -124,6 +149,7 @@ messages:
     Toggle: Vous avez basculé cet appareil pour !price!
     Device: Vous avez temporairement activé ce dispositif pour !price!
     Heal: Vous vous êtes guéri pour !price!
+    Repair: Vous avez réparé un élément pour !price
     Dispose: Vous avez jeté des éléments!
     DeviceItem: Vous avez temporairement activé le dispositif des !items !
     iSlot: Vous avez gagné !items !
@@ -131,19 +157,27 @@ messages:
     iSellXP: Vous avez vendu !xp points d'expérience pour !price!
     iBuyXP: Vous avez acheté !xp points d'expérience pour !price!
     iTrade: Vous avez échangé !chest1 pour !chest2!
-    TpToOwner: Vous serez téléporté au propriétaire !owner pour !price!
+    Trade: Vous avez échangé !chest1 pour !chest2!
+    TpToOwner: Vous vous êtes téléporté au propriétaire !owner pour !price!
     Class: Vous avez acheté l'ensemble contenant les articles !items pour !price!
     Disenchant: Vous avez retiré les enchantements sur l'objet dans votre main pour !price!
-    Command: Vous exécutez les commandes du panneau pour !price!
+    Command: Vous avez exécuté les commandes du panneau pour !price!
+    UserCommand: Vous avez exécuté les commandes du panneau pour !price!
+    Jukebox: Vous avez fait jouer un disque sur le Jukebox pour !price!
+    Kit: Vous avez acquis le kit contenant !items pour !price!
+    ResetKit: Vous avez réinitialisé les panneaux !param pour !price!
+    iXPBuy: Vous avez acheté !items pour !xp points XP!
+    iXPSell: Vous avez vendu !items pour !xp points XP!
+    Promote: Vous avez reçu une promotion de !permgroup à !promoteto!
+    TCommand: La commande sur ce panneasu sera exécutée dans 10 secondes!
+  
+  # Ces messages sont affichés au propriétaire de la boutique après que vous ayez utilisé leur panneau
   transaction_owner:
-    Heal: \!customer s'est guéri à votre station pour !price!
-    Repair: \!customer a réparé un article à votre station pour !price!
     Buy: \!customer vous a acheté !items pour !price!
     Sell: \!customer vous a vendu des !items pour !price!
     Donate: \!customer vous a fait don d'!items!
     DonateHand: \!customer vous a fait don de !items!
     Slot: \!customer a joué sur une machine à sous pour !price et a remporté !items!
-    Redstone: \!customer a activé votre machine à redstone pour !price!
     iBuy: ''
     iSell: ''
     gBuy: \!customer a acheté des !items de votre boutique fictive!
@@ -156,33 +190,94 @@ messages:
     DeviceOff: \!customer a désactivé votre appareil pour !price!
     Toggle: \!customer a basculé votre appareil pour !price!
     Device: \!customer a activé temporairement votre appareil pour !price!
+    Heal: \!customer s'est guéri à votre station pour !price!
+    Repair: \!customer a réparé un article à votre station pour !price!
     Dispose: ''
     DeviceItem: \!customer a activé temporairement votre appareil des !items!
     iSlot: ''
-    Enchant: \!customer a enchanté son article avec des enchantements pour !price!
+    Enchant: \!customer a enchanté son article pour !price!
     iSellXP: ''
     iBuyXP: ''
     iTrade: ''
+    Trade: \!customer vous a échangé !chest1 contre !chest2!
     TpToOwner: \!customer s'est téléporté jusqu'à vous pour !price!
     Class: ''
     Disenchant: ''
     Command: ''
+    UserCommand: ''
+    Jukebox: \!customer a fait jouer un disque sur votre Jukebox pour !price!
+    Kit: ''
+    ResetKit: ''
+    iXPBuy: ''
+    iXPSell: ''
+    Promote: ''
+    TCommand: ''
+
+# Ces messages sont utilisés par la commande /signshop sign SIGNNAME
+# De nouvelles lignes sont automatiquement faites à la fin des phrases au moment de l'affichage.
+# TODO / A FAIRE
+  help:
+    Buy: The Buy sign exchanges the customer's money for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
+    Sell: The Sell sign exchanges the customer's items for the owner's money. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
+    Donate: The Donate sign will give the chest's items.  You can put whatever you like on lines 2, 3, and 4 of this sign.  Punch the chest(s) with !linkmaterial containing the items you want to accept for donations.
+    DonateHand: The DonateHand sign will take the items from a customer's hand and give it to the chest.  You can put whatever you like on lines 2, 3, and 4 of this sign.  Punch the empty chest(s) with !linkmaterial that will hold the donated items.
+    Slot: The Slot sign exchanges the customer's money for the chest's randomly selected items.  Each slot in the chest has an equal probability of being selected.  The amount of items in each slot of the chest will be the amount of items the customer gets if that chest slot is selected (empty chest slots are ignored).
+    iBuy: The Infinite Buy sign exchanges the customer's money for items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of items, so the chest can be destroyed after linking.  Money is not put in the owner's account.
+    iSell: The Infinite Sell sign exchanges the customer's items for money. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of space in the chest, so the chest can be destroyed after linking.  Money is not removed from the owner's account.
+    gBuy: The Ghost Buy sign exchanges the customer's money for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not put in the owner's account.
+    gSell: The Ghost Sell sign exchanges the customer's items for money.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not removed from the owner's account.
+    Day: The Day sign exchanges the customer's money for setting the time to sunrise.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    Night: The Night sign exchanges the customer's money for setting the time to night.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    Rain: The Rain sign exchanges the customer's money for setting the weather to stormy.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    ClearSkies: The ClearSkies sign exchanges the customer's money for removing stormy weather.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    DeviceOn: The DeviceOn sign exchanges the customer's money for turning on a redstone lever.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to turn on using !linkmaterial.
+    DeviceOff: The DeviceOff sign exchanges the customer's money for turning off a redstone lever.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to turn off using !linkmaterial.
+    Toggle: The Toggle sign exchanges the customer's money for toggling a redstone lever on/off.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to toggle on/off using !linkmaterial.
+    Device: The Device sign exchanges the customer's money for temporarily turning a redstone lever on.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to temporarily turn on using !linkmaterial.
+    Heal: The Heal sign exchanges the customer's money for setting their health to full.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    Repair: The Repair sign exchanges the customer's money for fully repairing the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    Dispose: The Dispose sign will take the items from a customer's hand and destroy them.  You can put whatever you like on lines 2, 3, and 4 of this sign.
+    DeviceItem: The Device sign exchanges the customer's items for temporarily turning a redstone lever on.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to temporarily turn on using !linkmaterial.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
+    iSlot: The iSlot sign exchanges the customer's money for randomly selected items.  Each slot in the chest has an equal probability of being selected.  The amount of items in each slot of the chest will be the amount of items the customer gets if that chest slot is selected (empty chest slots are ignored).  This shop will never run out of items, so the chest can be destroyed after linking.  Money is not put in the owner's account.
+    Enchant: The Enchant sign exchanges the customer's money for enchanting the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  The enchantment is determined by an enchanted item in the chest.  Money is not put in the owner's account.
+    iSellXP: The Infinite Sell XP sign exchanges the customer's XP levels for money.  The 2nd line of this sign can say whatever you like, the XP levels goes on the 3rd and the price goes on the 4th.  Money is not put in the owner's account.
+    iBuyXP: The Infinite Buy XP sign exchanges the customer's money for XP levels.  The 2nd line of this sign can say whatever you like, the XP levels goes on the 3rd and the price goes on the 4th.  Money is not removed from the owner's account.
+    iTrade: The Infinite Trade sign exchanges the customer's items for the chest's items.  The 2nd, 3rd and 4th lines of this sign can say whatever you like.  Punch the chest of the items you want to receive using !linkmaterial, then punch the chest items you would like to give away, then punch the sign.  The items will not be added or removed from the chests, so they can be destroyed after linking.
+    Trade: The Trade sign exchanges the customer's items for the chest's items.  The 2nd, 3rd and 4th lines of this sign can say whatever you like.  Punch the chest of the items you want to receive using !linkmaterial, then punch the chest items you would like to give away, then punch the sign.
+    TpToOwner: The TpToOwner sign exchanges the customer's money for teleporting the themselves to the owner.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.  This is an example sign for custom commands, read more in the Quick Reference (found in the plugins/SignShop folder).
+    Class: The Class sign exchanges the customer's money and their inventory for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not put in the owner's account.
+    Disenchant: The Disenchant sign exchanges the customer's money for removing the enchantment on the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    Command: The Command sign exchanges the customer's money to run the command on the sign. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work.
+    UserCommand: The UserCommand sign exchanges the customer's money to run the command on the sign as if they typed it in. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work, or they don't have permission.
+    Share: The Share sign is used to share profits with other users.  List other usernames on the 2nd and/or 3rd lines of the sign.  The percentage you would like to share goes on the 4th line.  If you list multiple people on the sign, you put both percentages on the 4th line, separated by a "/".  Any remaining money is given to the owner of the shop.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
+    Restricted: The Restricted sign is used to make it so only certain permission groups can use a sign.  List the permission groups on the 2nd, 3rd, and/or 4th lines of the sign.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
+    Bank: The Bank sign is used to share profits with your bank account.  List a bank account you own on the 2nd line of the sign.  The percentage you would like to share goes on the 4th line.  Any remaining money is given to the owner of the shop.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
+    Jukebox: The Jukebox sign exchanges the customer's money to listen to music discs. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the music discs you'd like to play.  The sign will play the next disc in the chest when used.
+    Kit: The Kit sign exchanges the customer's money for the chest's items. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This sign can only be used once per player before needing to be reset.  Money is not put in the owner's account.
+    ResetKit: The ResetKit sign exchanges the customer's money so they are allowed to use the Kit sign again.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
+    iXPBuy: The Infinite XP Buy sign exchanges the customer's XP points for items.  The 2nd and 4th lines of this sign can say whatever you like, the XP points goes on the 3rd line.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of items, so the chest can be destroyed after linking.
+    iXPSell: The Infinite XP Sell sign exchanges the customer's items for XP points.  The 2nd and 4th lines of this sign can say whatever you like, the XP points goes on the 3rd line.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of space in the chest, so the chest can be destroyed after linking.
+    Promote: The Promote sign exchanges the customer's money to be added to a permission group.  The 2nd line of this sign must have the permission group listed.  The 3rd line can say anything.  The 4th line lists the amount of money required for the promotion.  Money is not put in the owner's account.
+    TCommand: The TCommand sign exchanges the customer's money to run the command on the sign after 10 seconds. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work.
+
+# Ces messages sont affichés pour informer l'utilisateur sur ce que SignShop est en train de faire
 errors:
-  no_permission: Vous n'avez pas la permission de créer ce signe!
-  no_permission_use: Vous n'avez pas la permission d'utiliser ce signe!
-  invalid_operation: Le signe sur lequel vous avez cliqué n'est pas valide!
-  chest_empty: Le magasin est vide!
+  no_permission: Vous n'avez pas la permission de créer ce panneau!
+  no_permission_use: Vous n'avez pas la permission d'utiliser ce panneau!
+  no_permission_changeowner: Vous n'avez pas la permission de changer le propriétaire de cette boutique!
+  invalid_operation: Le panneau sur lequel vous avez cliqué n'est pas valide!
+  chest_empty: Ce magasin est vide!
   chest_missing: Vous devez lier au moins un coffre avec ce magasin!
   lever_missing: Vous devez lier au moins un levier pour ce magasin!
-  no_player_money: Vous n'avez pas assez d'argent pour effectuer cet achat (!price)!
+  no_player_money: Vous n'avez pas la somme de !price pour payer!
   no_shop_money: Le magasin n'a pas la somme de !price pour vous payer!
   out_of_business: Cette boutique semble avoir disparu du marché!
   out_of_stock: Cette boutique est en rupture de stock!
-  overstocked: Cette boutique est surchargée, demandez au propriétaire de vider le stock!
-  player_doesnt_have_items: Vous n'avez pas les !items!
+  overstocked: Cette boutique est surchargée!
+  player_doesnt_have_items: Vous n'avez pas les items! (!items)
   no_item_in_hand: Vous devez tenir un objet en main pour que le magasin puisse le prendre!
-  player_overstocked: Votre inventaire est trop plein!
-  sign_location_stored: Emplacement du signe mémorisé!
+  player_overstocked: Votre inventaire est trop plein, ou vous ne pouvez pas posséder plus d'argent!
+  sign_location_stored: Emplacement du panneau mémorisé!
   made_day: \!customer a fait apparaître le jour!
   made_night: \!customer a fait apparaître la nuit!
   made_rain: \!customer a fait pleuvoir!
@@ -194,17 +289,18 @@ errors:
   already_raining: Il pleut déjà!
   already_clear_skies: Le ciel est déjà clair!
   already_full_health: Votre santé est déjà bien remplie!
-  saving: Enregistrement des magasins ...
+  saving: Sauvegarde des magasins ...
   saved: Magasins sauvegardés!
   shop_removed: Suppression d'une boutique invalide! Il devrait être en '!world' (!x,!y,!z).
   invalid_item_to_repair: Cet objet ne peut pas être réparé!
   no_item_to_repair: Vous devez tenir en main l'objet que vous voulez réparer!
   backup_fail: Échec de la sauvegarde de stockage!
-  too_far: La distance entre le signe et le coffre est trop grande. Le maximum est de !Max!
+  too_far: La distance entre le panneau et le coffre est trop grande. Le maximum est de !Max!
   too_many_shops: Vous avez atteint la quantité maximale de magasins autorisés. Le maximum est de !Max!
   enchanted_not_allowed: Vous n'êtes pas autorisé à réparer des objets enchantés!
   enchantment_missing: Au moins un objet enchanté est nécessaire, mettez en un dans le(s) coffre(s)!
   item_not_enchantable: L'article dans votre main n'est pas enchantable!
+  item_already_enchanted: L'article dans votre main a déjà été enchanté avec les enchantements qui vous font offerts!
   no_player_xp: Vous n'avez pas assez d'expérience pour vendre (!xp)!
   no_item_to_disenchant: Vous devez tenir en main l'objet que vous voulez désenchanter!
   nothing_to_disenchant: Cet objet ne peut pas être désenchanté!
@@ -212,30 +308,78 @@ errors:
   no_permit_owner: Le propriétaire de cette boutique n'est plus autorisé!
   need_permit: Il faut être autorisé pour mettre en place cette boutique!
   villager_trading_disabled: Les échanges avec les villageois ne sont pas autorisés sur ce serveur!
-  not_allowed_to_link_sharesigns: Vous n'êtes pas autorisé à lier les signes partagés à ce magasin!
-  no_shop_linked_to_sharesign: Ce signe Partagez n'a pas été lié à tous les magasins!
-  share_sign_splits_profit: Ce signe se partage les bénéfices entre les !profits pour la boutique (s) à !profitshops!
-  registered_share_sign: Pour inscrire le signe Partager, cliquer sur le signe magasin le plus proche!
-  unlinked_share_sign: Signe Partager délié de la boutique!
-  linked_share_sign: Signe Partager lié à la boutique avec succès!
-  not_allowed_to_link_restrictedsigns: Vous n'êtes pas autorisé à lier signes affectés à ce magasin!
-  no_shop_linked_to_restrictedsign: Ce signe restreint n'a pas été lié à tous les magasins!
-  registered_restricted_sign: Inscrit le signe restreint, s'il vous plaît cliquer sur le signe magasin le plus proche!
-  unlinked_restricted_sign: Le signe restreint à été délié!
-  linked_restricted_sign: Signe Restreint lié à la boutique avec succès!
-  restricted_sign_restricts: Ce signe Restreint limite l'utilisation de la boutique(s) à !restrictedshops!
+  not_allowed_to_link_sharesigns: Vous n'êtes pas autorisé à lier les panneaux partagés à ce magasin!
+  no_shop_linked_to_sharesign: Ce panneau Partager n'a pas été lié à tous les magasins!
+  share_sign_splits_profit: Ce panneau Partager distribue les bénéfices entre les !profits pour la(les) boutique(s) à !profitshops!
+  registered_share_sign: Pour inscrire le panneau Partager, cliquer sur le panneau magasin le plus proche!
+  unlinked_share_sign: Panneau Partager délié de la boutique!
+  linked_share_sign: Panneau Partager lié à la boutique avec succès!
+  not_allowed_to_link_restrictedsigns: Vous n'êtes pas autorisé à lier panneaux affectés à ce magasin!
+  no_shop_linked_to_restrictedsign: Ce panneau Restreint n'a pas été lié à tous les magasins!
+  registered_restricted_sign: Panneau Restreint enregistré, veuillez maintenant cliquer sur le panneau du magasin!
+  unlinked_restricted_sign: Le panneau Restreint à été délié!
+  linked_restricted_sign: Panneau Restreint lié à la boutique avec succès!
+  restricted_sign_restricts: Ce panneau Restreint limite l'utilisation de la boutique(s) à !restrictedshops!
   towny_insufficient_funds: Manque de fonds dans le compte de la boutique!
   towny_owner_not_mayor_or_assistant: Le propriétaire de la boutique n'est pas maire ou adjoint d'une ville!
   towny_owner_not_belong_to_town: Le propriétaire du magasin ne devrait pas appartenir à une ville!
   towny_bank_withdrawls_not_allowed: La configuration actuelle de Towny ne permet pas des retraits bancaires!
-  restricted_from_using: Vous êtes limité dans l'utilisation de ce magasin!
-  restricted_but_owner: Vous n'êtes pas limité à l'utilisation de cette boutique car vous êtes le propriétaire!
-  item_on_blacklist: L'article !blacklisted_item est sur LISTE NOIRE et ne peut donc pas être utilisé!
-  item_on_blacklist_but_op: L'article !blacklisted_item est sur LISTE NOIRE, mais vous êtes OP!
+  restricted_from_using: Il vous est interdit d'utiliser cette boutique!
+  restricted_but_owner: Cette boutique ne vous est pas interdite car vous en êtes le propriétaire!
+  item_on_blacklist: L'article !blacklisted_item est sur une liste d'interdictions (blacklist) et ne peut donc pas être utilisé!
+  item_on_blacklist_but_op: L'article !blacklisted_item est sur liste d'interdictions (blacklist), mais vous êtes OP!
+  item_not_on_whitelist: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist) et ne peut donc pas être utilisé dans les boutiques.
+  item_not_on_whitelist_but_op: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist), mais vous êtes OP!
+
+  #TODO / A FAIRE
+  block_is_protected: This block is protected, you are not allowed to interact with it.
+  updated_shop: The shop has been succesfully updated.
+  failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur ci-haut!
+  price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire d'économie Essentials. Il peut donc varier.
+  only_one_time: You can only use this shop once.
+  nothing_to_reset_ontime: You are already allowed to use !param signs one time. So there's nothing to reset.
+  shop_on_cooldown: Ce magasin termine une transaction. Veuillez patienter !cooldownleft secondes.
+  damaged_items_shop_homogeneous: A shop accepting damaged items can only deal in one type of item! Damaged items are not accepted until the shop is fixed.
+  use_item_to_destroy_shop: This shop is protected and can only be destroyed with a(n) !destroymaterial.
+  no_items_defined_for_shop: There are no items defined for this shop, can not complete the operation.
+  notifications_shop_built: \!player just created a(n) !signtype sign at (!x, !y, !z)
   shop_contains: Ce magasin contient !shopinventory @ !items pour !price!
+  not_allowed_to_link_banksigns: You are not allowed to link Bank signs to this shop!
+  no_shop_linked_to_banksign: This Bank sign has not been linked to any shops.
+  bank_sign_linked_to_banks: This Bank sign communicates with bank called !bank in the name of the shops at !bankshops
+  registered_bank_sign: Registered a Bank sign, please click the Shop sign next.
+  unlinked_bank_sign: Unlinked Bank sign from Shop.
+  linked_bank_sign: Succesfully linked Bank sign to Shop.
+  not_allowed_to_use_bank: You are not the owner or a member of !bank Bank so the related Bank sign will be ignored.
+  no_bank_available: There is no Bank available to process the request, please contact the shop owner.
+  no_bank_support: The Economy plugin installed on this server does not support Banks.
+  repeated_x_times: (repeated !times times)
   removed_location: Emplacement supprimé!
   stored_location: Emplacement de !block enregistré!
   stored_location_containable: Emplacement de !block contenant !items enregistré!
-  failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur ci-haut!
-  price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire d'économie Essentials. Il est donc variable.
-  shop_on_cooldown: Ce magasin termine une transaction. Veuillez patienter !cooldownleft secondes.
+  region_does_not_allow_shops: Shops are not allowed within this region. Please move the sign somewhere else.
+  region_allow_shops_but_op: This shop is not in a region with the "allow-shop" flag set to true but you are OP.
+  region_allow_shops_but_perm: This shop is not in a region with the "allow-shop" flag set to true but you have the bypass permission node.
+  towny_shop_plot_not_allowed: This shop is not on a shop plot, please move it.
+  towny_shop_plot_not_allowed_but_op: This shop is not on a shop plot but you are OP.
+  towny_shop_plot_not_allowed_but_perm: This shop is not on a shop plot but you have the bypass permission node.
+  deselected_hanging: You have deselected a Hanging item.
+  selected_hanging: You have selected a Hanging item.
+  itemframe_unlinked: ItemFrame has been successfully unlinked.
+  itemframe_linked: ItemFrame has been successfully linked.
+  itemframe_already_linked: This ItemFrame is already linked to another shop.
+  shop_is_now_protected: Your chest(s) have been locked automatically.
+  not_allowed_to_rotate_frame: You are not allowed to rotate this ItemFrame.
+  no_permission_plugin: No permission plugin could be found.
+  missing_promote_group: Please write the Permission group to promote to on the second line.
+  promote_group_does_not_exist: The Permission group on the second line does not exist.
+  not_in_permission_group: You aren't in a permission group yet.
+  already_in_promote_group: You are already in the group.
+  could_not_remove_primary_group: Could not remove you from your primary group
+  could_not_promote: Could not promote you.
+  must_be_op_to_run: You do not have the right permission to run this command, it is for OPs only.
+  not_allowed_on_plot: You are not allowed to link this on this plot!
+  not_allowed_on_plot_but_op: You are not allowed to link this on this plot, but you are OP.
+  exceeded_max_amount_of_chests_per_shop: You have exceeded the maximum amount of chests (!maxAmountOfChests) that can be linked to a single shop. Please unlink one or more before continuing.
+  this_shop_exceeded_max_amount_of_chests: Shop in world '!world' at (!x, !y, !z) exceeds the maximum amount of chests per shop!
+  could_not_complete_operation: Could not complete operation, contact your System Administrator and checks the logs.

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -9,12 +9,15 @@ signs:
   Acheter: Buy
   Vendre: Sell
   Donner: Donate
+  Hasard: Slot
   Sous: Slot
   iAcheter: iBuy
   gVendre: gSell
+  gAcheter: gBuy
   Jour: Day
   Nuit: Night
   Pluie: Rain
+  BeauTemps: ClearSkies
   CielClair: ClearSkies
   AppareilOn: DeviceOn
   AppareilOff: DeviceOff
@@ -24,14 +27,18 @@ signs:
   Guérir: Heal
   Jeter: Dispose
   AppareilItem: DeviceItem
+  iHasard: iSlot
   iSous: iSlot
   Enchanter: Enchant
   iAcheterXP: iBuyXP
   iVendreXP: iSellXP
   iTroquer: iTrade
   TpToOwner: TpToOwner
+  TpProprio: TpToOwner
   Classe: Class
   Commande: Command
+  CommandeUtil: UserCommand
+  TCommande: TCommand
   Partager: Share
   Restreint: Restricted
   iVendre: iSell
@@ -42,6 +49,8 @@ signs:
   VendreXP: iSellXP
   DonnerMain: DonateHand
   Slot: Slot
+  ReinitKit: ResetKit
+  Promotion: Promote
 
 
 # Messages apparaissant quand les joueurs interagissent avec les panneaux
@@ -79,13 +88,13 @@ messages:
     Class: Vous avez configuré une boutique pour vendre un ensemble d'articles pour !price.
     Disenchant: Vous avez configuré un panneau qui élimine les enchantements pour !price.
     Command: Vous avez configuré un panneau qui exécute des commandes pour !price.
-    UserCommand: Vous avez configuré un panneau qui exécute des commandes comme si un jour les avait tappées dans le chat pour !price.
+    UserCommand: Vous avez configuré un panneau qui exécute des commandes comme si un joueur les avait tappées dans le chat pour !price.
     Jukebox: Vous avez configuré un Jukebox qui joue les disques du coffre pour !price.
     Kit: Vous avez configuré un kit d'items à usage unique (!items) pour !price.
     ResetKit: Vous avez configuré un panneau qui réinitialise les panneaux !param.
     iXPBuy: Vous avez mis en vente !items au prix de !xp points XP.
     iXPSell: Vous avez configuré une vente illimitée de !items pour !xp points XP.
-    Promote: Vous avez configuré un panneau de promotion qui promouvoit l'utilisateur au groupe !promoteto.
+    Promote: Vous avez configuré un panneau de promotion qui ajoute l'utilisateur au groupe !promoteto.
     TCommand: Vous avez configuré un panneau qui exécute les commandes sur ce panneau après 10 secondes pour !price.
   
   # Messages affichés quand vous faites un clic gauche sur un panneau
@@ -217,48 +226,49 @@ messages:
 # De nouvelles lignes sont automatiquement faites à la fin des phrases au moment de l'affichage.
 # TODO / A FAIRE
   help:
-    Buy: The Buy sign exchanges the customer's money for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
-    Sell: The Sell sign exchanges the customer's items for the owner's money. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
-    Donate: The Donate sign will give the chest's items.  You can put whatever you like on lines 2, 3, and 4 of this sign.  Punch the chest(s) with !linkmaterial containing the items you want to accept for donations.
-    DonateHand: The DonateHand sign will take the items from a customer's hand and give it to the chest.  You can put whatever you like on lines 2, 3, and 4 of this sign.  Punch the empty chest(s) with !linkmaterial that will hold the donated items.
-    Slot: The Slot sign exchanges the customer's money for the chest's randomly selected items.  Each slot in the chest has an equal probability of being selected.  The amount of items in each slot of the chest will be the amount of items the customer gets if that chest slot is selected (empty chest slots are ignored).
-    iBuy: The Infinite Buy sign exchanges the customer's money for items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of items, so the chest can be destroyed after linking.  Money is not put in the owner's account.
-    iSell: The Infinite Sell sign exchanges the customer's items for money. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of space in the chest, so the chest can be destroyed after linking.  Money is not removed from the owner's account.
-    gBuy: The Ghost Buy sign exchanges the customer's money for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not put in the owner's account.
-    gSell: The Ghost Sell sign exchanges the customer's items for money.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not removed from the owner's account.
-    Day: The Day sign exchanges the customer's money for setting the time to sunrise.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    Night: The Night sign exchanges the customer's money for setting the time to night.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    Rain: The Rain sign exchanges the customer's money for setting the weather to stormy.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    ClearSkies: The ClearSkies sign exchanges the customer's money for removing stormy weather.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    DeviceOn: The DeviceOn sign exchanges the customer's money for turning on a redstone lever.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to turn on using !linkmaterial.
-    DeviceOff: The DeviceOff sign exchanges the customer's money for turning off a redstone lever.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to turn off using !linkmaterial.
-    Toggle: The Toggle sign exchanges the customer's money for toggling a redstone lever on/off.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to toggle on/off using !linkmaterial.
-    Device: The Device sign exchanges the customer's money for temporarily turning a redstone lever on.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to temporarily turn on using !linkmaterial.
-    Heal: The Heal sign exchanges the customer's money for setting their health to full.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    Repair: The Repair sign exchanges the customer's money for fully repairing the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    Dispose: The Dispose sign will take the items from a customer's hand and destroy them.  You can put whatever you like on lines 2, 3, and 4 of this sign.
-    DeviceItem: The Device sign exchanges the customer's items for temporarily turning a redstone lever on.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the lever(s) you want to temporarily turn on using !linkmaterial.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.
-    iSlot: The iSlot sign exchanges the customer's money for randomly selected items.  Each slot in the chest has an equal probability of being selected.  The amount of items in each slot of the chest will be the amount of items the customer gets if that chest slot is selected (empty chest slots are ignored).  This shop will never run out of items, so the chest can be destroyed after linking.  Money is not put in the owner's account.
-    Enchant: The Enchant sign exchanges the customer's money for enchanting the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  The enchantment is determined by an enchanted item in the chest.  Money is not put in the owner's account.
-    iSellXP: The Infinite Sell XP sign exchanges the customer's XP levels for money.  The 2nd line of this sign can say whatever you like, the XP levels goes on the 3rd and the price goes on the 4th.  Money is not put in the owner's account.
-    iBuyXP: The Infinite Buy XP sign exchanges the customer's money for XP levels.  The 2nd line of this sign can say whatever you like, the XP levels goes on the 3rd and the price goes on the 4th.  Money is not removed from the owner's account.
-    iTrade: The Infinite Trade sign exchanges the customer's items for the chest's items.  The 2nd, 3rd and 4th lines of this sign can say whatever you like.  Punch the chest of the items you want to receive using !linkmaterial, then punch the chest items you would like to give away, then punch the sign.  The items will not be added or removed from the chests, so they can be destroyed after linking.
-    Trade: The Trade sign exchanges the customer's items for the chest's items.  The 2nd, 3rd and 4th lines of this sign can say whatever you like.  Punch the chest of the items you want to receive using !linkmaterial, then punch the chest items you would like to give away, then punch the sign.
-    TpToOwner: The TpToOwner sign exchanges the customer's money for teleporting the themselves to the owner.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.  This is an example sign for custom commands, read more in the Quick Reference (found in the plugins/SignShop folder).
-    Class: The Class sign exchanges the customer's money and their inventory for the chest's items.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  Money is not put in the owner's account.
-    Disenchant: The Disenchant sign exchanges the customer's money for removing the enchantment on the item in their hands.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    Command: The Command sign exchanges the customer's money to run the command on the sign. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work.
-    UserCommand: The UserCommand sign exchanges the customer's money to run the command on the sign as if they typed it in. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work, or they don't have permission.
-    Share: The Share sign is used to share profits with other users.  List other usernames on the 2nd and/or 3rd lines of the sign.  The percentage you would like to share goes on the 4th line.  If you list multiple people on the sign, you put both percentages on the 4th line, separated by a "/".  Any remaining money is given to the owner of the shop.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
-    Restricted: The Restricted sign is used to make it so only certain permission groups can use a sign.  List the permission groups on the 2nd, 3rd, and/or 4th lines of the sign.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
-    Bank: The Bank sign is used to share profits with your bank account.  List a bank account you own on the 2nd line of the sign.  The percentage you would like to share goes on the 4th line.  Any remaining money is given to the owner of the shop.  Punch this sign and then any active shop signs you own with !linkmaterial to activate.
-    Jukebox: The Jukebox sign exchanges the customer's money to listen to music discs. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the music discs you'd like to play.  The sign will play the next disc in the chest when used.
-    Kit: The Kit sign exchanges the customer's money for the chest's items. The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This sign can only be used once per player before needing to be reset.  Money is not put in the owner's account.
-    ResetKit: The ResetKit sign exchanges the customer's money so they are allowed to use the Kit sign again.  The 2nd and 3rd lines of this sign can say whatever you like, the price goes on the 4th.  Money is not put in the owner's account.
-    iXPBuy: The Infinite XP Buy sign exchanges the customer's XP points for items.  The 2nd and 4th lines of this sign can say whatever you like, the XP points goes on the 3rd line.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of items, so the chest can be destroyed after linking.
-    iXPSell: The Infinite XP Sell sign exchanges the customer's items for XP points.  The 2nd and 4th lines of this sign can say whatever you like, the XP points goes on the 3rd line.  Punch the chest(s) using !linkmaterial containing the type and amount of items you want for a single transaction.  This shop will never run out of space in the chest, so the chest can be destroyed after linking.
-    Promote: The Promote sign exchanges the customer's money to be added to a permission group.  The 2nd line of this sign must have the permission group listed.  The 3rd line can say anything.  The 4th line lists the amount of money required for the promotion.  Money is not put in the owner's account.
-    TCommand: The TCommand sign exchanges the customer's money to run the command on the sign after 10 seconds. The 2nd and 3rd lines of this sign have the command written on them (without the "/"), the price goes on the 4th.  SignShop cannot know if the command was successfully completed, so it will take the customer's money even if the command doesn't work.
+    Buy: Le panneau Acheter échange l'argent du client contre des items dans le coffre. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction.
+    Sell: Le panneau Vendre échange les items du client contre l'argent du propriétaire de la boutique. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction.
+    Donate: Le panneau Donner va donner les items dans le coffre. Sur la 2ème, la 3ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction.
+    DonateHand: Le panneau DonnerMain va prendre l'item qui se trouve dans la main du joueur et le mettre dans le coffre. Sur la 2ème, la 3ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Avec !linkmaterial, frappez le coffre vide qui recevra les items donnés.
+    Slot: Le panneau Hasard échange l'argent du client contre des items choisis au hasard dans le coffre. Tous les emplacements du coffre ont une chance égale d'être sélectionnés. Le nombre d'items dans chaque emplacement correspond au nombre d'items qui seront remis au client si cet emplacement est sélectionné. De plus, les coffres vides sont ignorés.
+    iBuy: Le panneau Achat Infini échange l'argent du client contre des items. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. Cette boutique ne manquera jamais d'items, donc le coffre peut être détruit après la liaison. L'argent ne sera pas déposé dans le compte du propriétaire.
+    iSell: Le panneau Vente Infinie échange les items du client contre de l'argent. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. Cette boutique ne manquera jamais d'espace dans le coffre. Il peut donc être détruit après la liaison. L'argent ne sera pas prélevé dans le compte du propriétaire.    
+    gBuy: Le panneau Achat Fantôme échange l'argent du client contre des items dans le coffre. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. L'argent n'est pas déposé dans le compte du propriétaire.
+    gSell: Le panneau Vente Fantôme échange les items du client contre de l'argent. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. L'argent n'est pas prélevé dans le compte du propriétaire.
+    Day: Le panneau Jour prélève l'argent du client  pour définir l'heure au lever du Soleil. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    Night: Le panneau Nuit prélève l'argent du client pour définir l'heure au coucher du Soleil. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    Rain: Le panneau Nuit prélève l'argent du client pour définir la météo en Pluie. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    ClearSkies: Le panneau BeauTemps prélève l'argent du client pour définir la météo en beau temps. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    DeviceOn: Le panneau AppareilOn échange l'argent du client contre l'activation d'un levier de redstone. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le(s) levier(s) que vous désirez activer.
+    DeviceOff: Le panneau AppareilOff échange l'argent du client contre la désactivation d'un levier de redstone. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le(s) levier(s) que vous désirez désactiver.
+    Toggle: Le panneau Basculer échange l'argent du client contre la bascule (on/off) d'un levier de redstone. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le(s) levier(s) que vous désirez basculer.
+    Device: Le panneau Appareil échange l'argent du client contre l'activation temporaire d'un levier de redstone. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le(s) levier(s) que vous désirez activer temporairement.
+    Heal: Le panneau Santé échange l'argent du client contre un rétablissement complet de la santé. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    Repair: Le panneau Réparer échange l'argent du client contre la réparation complète de l'item dans leur main. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.    
+    Dispose: Le panneau Jeter détruit l'item dans la main du client. Sur la 2ème, la 3ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez.
+    DeviceItem: Le panneau AppareilItem échange les items du client contre l'activation temporaire d'un levier de redstone. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le(s) levier(s) que vous désirez activer temporairement. Avec !linkmaterial, frappez le coffre contenant le type et le nombre d'items que vous désirez pour une seule transaction.
+    iSlot: Le panneau Hasard Infini échange l'argent du client contre des items choisis au hasard. Tous les emplacements du coffre ont une chance égale d'être sélectionnés. Le nombre d'items dans chaque emplacement correspond au nombre d'items qui seront remis au client si cet emplacement est sélectionné. De plus, les coffres vides sont ignorés. Cette boutique ne manquera jamais d'items, donc le coffre peut être détruit après la liaison. L'argent ne sera pas déposé dans le compte du propriétaire.    
+    Enchant: Le panneau Enchanter échange l'argent du client contre l'enchantement de l'item dans leur main. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Le type d'enchantement(s) est déterminé par l'item enchanté dans le coffre. L'argent n'est pas déposé dans le compte du propriétaire.
+    iSellXP: Le panneau Vente Infinie d'XP échange des niveaux d'XP du client contre de l'argent. Sur la 2ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 3ème ligne, inscrivez le nombre de niveaux XP. Sur la 4ème ligne, inscrivez le prix. Les niveaux d'XP ne sont pas transférés au propriétaire.
+    iBuyXP: Le panneau Achat Infini d'XP échange l'argent du client contre des niveaux d'XP. Sur la 2ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 3ème ligne, inscrivez le nombre de niveaux XP. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas prélevé dans le compte du propriétaire.
+    iTrade: Le panneau Échange Infini échange les items du client contre lers items du coffre. Sur la 2ème, la 3ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Avec !linkmaterial, frappez le coffre contenant les items vous souhaitez recevoir, puis frappez le coffre contenant les items que vous souhaitez donner en échange. Frappez finalement le panneau. Les items ne seront pas ajoutés ni supprimés des coffres, ils peuvent donc être détruits après la liaison.
+    Trade: Le panneau Échange échange les items du client contre lers items du coffre. Sur la 2ème, la 3ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Avec !linkmaterial, frappez le coffre contenant les items vous souhaitez recevoir, puis frappez le coffre contenant les items que vous souhaitez donner en échange. Frappez finalement le panneau.
+    TpToOwner: Le panneau TP Propriétaire échange l'argent du client contre la téléportation au propriétaire. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire. Ce panneau est un exemple de commande personnalisée. Pour en savoir plus, consultez la Référence Rapide (dans le dossier plugins/SignShop)
+    Class:  Le panneau classe échange de l'argent et des items dans l'inventaire du client contre les items du coffre. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items que vous désirez pour une seule transaction. L'argent n'est pas déposé dans le compte du propriétaire.
+    Disenchant: Le panneau Désenchanter prélève l'argent du client pour désenchanter l'item dans leur main. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    Command: Le panneau Commande échange l'argent du client contre l'exécution de la commande inscrite sur le panneau. Sur la 2ème et la 3ème ligne, inscrivez la commande à exécuter (sans le "/"). Sur la 4ème ligne, inscrivez le prix. SignShop ne peut pas savoir is la commande s'est exécutée avec succès, l'argent du client sera donc prélevé même si la commande ne fonctionne pas.
+    UserCommand: Le panneau Commande Utilisateur échange l'argent du client contre l'exécution de la commande inscrite sur le panneau, conmme si le client l'avait entrée dans le chat. Sur la 2ème et la 3ème ligne, inscrivez la commande à exécuter (sans le "/"). Sur la 4ème ligne, inscrivez le prix. SignShop ne peut pas savoir is la commande s'est exécutée avec succès, l'argent du client sera donc prélevé même si la commande ne fonctionne pas où si le client n'a pas la permission.    
+    Share: Le panneau Partage est utilisé pour partager les profits avec d'autres utilisateurs. Sur la 2ème et la 3ème ligne, inscrivez les noms d'utilisateur. Sur la 4ème ligne, inscrivez le pourcentage que vous désirez partager. Si vous inscrivez plusieurs utilisateurs, vous pouvez définir des pourcentages différents sur la 4ème ligne, en les séparant par un "/". Tout l'argent restant est donné au propriétaire de la boutique. Avec !linkmaterial, frappez d'abord ce panneau, puis frappez tout autre panneau que vous possédez, pour l'activer.
+    Restricted: Le panneau Restreint est utilisé pour faire en sorte que seuls les membres de certains groupes de permission peuvent utiliser un panneau. Sur les lignes 2, 3 et 4 du panneau, inscrivez les groupes de permissions. Avec !linkmaterial, frappez d'abord ce panneau, puis frappez tout autre panneau que vous possédez, pour l'activer.
+    Bank: Le panneau Banque est utilisé pour partager les profits avec votre compte en banque. Sur la 2ème ligne du panneau, inscrivez votre compte en banque. Sur la 4ème ligne, inscrivez le pourcentage qui sera partagé. L'argent restant est donné au propriétaire. Avec !linkmaterial, frappez d'abord ce panneau, puis frappez tout autre panneau que vous possédez, pour l'activer.
+    Jukebox: Le panneau Jukebox échange l'argent du client contre l'écoute de disques. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant les disques de musique que vous souhaitez rendre accessibles. Le panneau jouera le prochain disque dans le coffre lorsqu'il est utilisé.
+    Kit: Le panneau Kit échange l'argent du client contre les items dans le coffre. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. Ce panneau ne peut être utilisé qu'une seule fois par joueur avant de devoir être réintiialisé. L'argent n'est pas déposé dans le coffre du propriétaire.    
+    ResetKit: Le panneau Réinitialiser Kit échange l'argent du client contre la réinitialisation d'un panneau Kit, pour qu'ils puissent l'utiliser à nouveau. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    iXPBuy: Le panneau Achat Infini XP échange des points XP du client contre des items. Sur la 2ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 3ème ligne, inscrivez le nombre de points XP. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction. Cette boutique ne manquera jamais d'items, donc le coffre peut être détruit après la liaison. Les points d'XP ne sont pas transférés au propriétaire.    
+    iXPSell: Le panneau Vente Infinie XP échange des itemps du client contre des points XP. Sur la 2ème et la 4ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 3ème ligne, inscrivez le nombre de points XP. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items que vous désirez pour une seule transaction. Cette boutique ne manquera jamais d'espace dans le coffre, donc le coffre peut être détruit après la liaison. Les points d'XP ne sont pas prélevés du propriétaire.    
+    Promote: Le panneau Promotion échange l'argent du client contre l'ajout à un groupe de permissions. Sur la 2ème ligne, vous devez inscrire le groupe de permissions. Sur la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. L'argent n'est pas déposé dans le compte du propriétaire.
+    TCommand: Le panneau TCommande échange l'argent du client contre l'exécution de la commande inscrite sur le panneau après 10 secondes. Sur la 2ème et la 3ème ligne, inscrivez la commande à exécuter (sans le "/"). Sur la 4ème ligne, inscrivez le prix. SignShop ne peut pas savoir is la commande s'est exécutée avec succès, l'argent du client sera donc prélevé même si la commande ne fonctionne pas.
+
 
 # Ces messages sont affichés pour informer l'utilisateur sur ce que SignShop est en train de faire
 errors:
@@ -330,7 +340,6 @@ errors:
   item_on_blacklist_but_op: L'article !blacklisted_item est sur liste d'interdictions (blacklist), mais vous êtes OP!
   item_not_on_whitelist: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist) et ne peut donc pas être utilisé dans les boutiques.
   item_not_on_whitelist_but_op: L'item !blacklisted_item ne figure pas sur la liste d'autorisations (whitelist), mais vous êtes OP!
-
   block_is_protected: Ce bloc est prorégé, vous n'êtes pas autorisé à interagir avec celui-ci.
   updated_shop: La boutique a été mise à jour avec succès.
   failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur ci-haut!

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -48,10 +48,8 @@ messages:
     Slot: Vous avez configuré une machine à sous à !price offrant !items.
     iBuy: Vous avez créé une vente illimitée de !items pour !price.
     iSell: Vous avez créé un achat illimité de !items pour !price.
-    gBuy: Vous avez configuré un magasin fictif vendant des !items pour !price.
-      (Notez que vous ne recevrez pas d'argent de cette boutique)
-    gSell: Vous avez configuré un achat fictif de !items pour !price. (Notez
-      que vous ne recevrez pas d'argent de cette boutique)
+    gBuy: Vous avez configuré un magasin fictif vendant des !items pour !price. (Notez que vous ne recevrez pas d'argent de cette boutique)
+    gSell: Vous avez configuré un achat fictif de !items pour !price. (Notez que vous ne recevrez pas d'argent de cette boutique)
     Day: Vous avez configuré un contrôleur de jour pour un coût de !price.
     Night: Vous avez configuré un contrôleur de nuit pour un coût de !price.
     Rain: Vous avez configuré un contrôleur de pluie pour un coût de !price.
@@ -63,8 +61,7 @@ messages:
     Heal: Vous avez configuré une station de guérison pour un coût de !price.
     Repair: Vous avez configuré une station de réparation pour un coût de !price.
     Dispose: Vous avez configuré un signe Jeter.
-    DeviceItem: Vous avez configuré un dispositif activateur temporaire pour un coût
-      de !items!
+    DeviceItem: Vous avez configuré un dispositif activateur temporaire pour un coût de !items!
     iSlot: Vous avez configuré une machine à sous illimitée offrant !items pour !price.
     Enchant: Vous avez configuré un enchanteur qui coûte !price et enchante avec !enchantements.
     iSellXP: Vous avez configuré un achat illimité de !xp au prix de !price.
@@ -181,11 +178,9 @@ errors:
   no_shop_money: Le magasin n'a pas la somme de !price pour vous payer!
   out_of_business: Cette boutique semble avoir disparu du marché!
   out_of_stock: Cette boutique est en rupture de stock!
-  overstocked: Cette boutique est surchargée, demandez au propriétaire de vider le
-    stock!
+  overstocked: Cette boutique est surchargée, demandez au propriétaire de vider le stock!
   player_doesnt_have_items: Vous n'avez pas les !items!
-  no_item_in_hand: Vous devez tenir un objet en main pour que le magasin puisse le
-    prendre!
+  no_item_in_hand: Vous devez tenir un objet en main pour que le magasin puisse le prendre!
   player_overstocked: Votre inventaire est trop plein!
   sign_location_stored: Emplacement du signe mémorisé!
   made_day: \!customer a fait apparaître le jour!
@@ -201,18 +196,14 @@ errors:
   already_full_health: Votre santé est déjà bien remplie!
   saving: Enregistrement des magasins ...
   saved: Magasins sauvegardés!
-  shop_removed: Suppression d'une boutique invalide! Il devrait être en '!world' (!x,!y,
-    !z).
+  shop_removed: Suppression d'une boutique invalide! Il devrait être en '!world' (!x,!y,!z).
   invalid_item_to_repair: Cet objet ne peut pas être réparé!
   no_item_to_repair: Vous devez tenir en main l'objet que vous voulez réparer!
   backup_fail: Échec de la sauvegarde de stockage!
-  too_far: La distance entre le signe et le coffre est trop grande. Le maximum est
-    de !Max!
-  too_many_shops: Vous avez atteint la quantité maximale de magasins autorisés. Le
-    maximum est de !Max!
+  too_far: La distance entre le signe et le coffre est trop grande. Le maximum est de !Max!
+  too_many_shops: Vous avez atteint la quantité maximale de magasins autorisés. Le maximum est de !Max!
   enchanted_not_allowed: Vous n'êtes pas autorisé à réparer des objets enchantés!
-  enchantment_missing: Au moins un objet enchanté est nécessaire, mettez en un dans
-    le(s) coffre(s)!
+  enchantment_missing: Au moins un objet enchanté est nécessaire, mettez en un dans le(s) coffre(s)!
   item_not_enchantable: L'article dans votre main n'est pas enchantable!
   no_player_xp: Vous n'avez pas assez d'expérience pour vendre (!xp)!
   no_item_to_disenchant: Vous devez tenir en main l'objet que vous voulez désenchanter!
@@ -220,46 +211,31 @@ errors:
   multiworld_not_allowed: Les magasins Multiworld ne sont pas autorisés sur ce serveur!
   no_permit_owner: Le propriétaire de cette boutique n'est plus autorisé!
   need_permit: Il faut être autorisé pour mettre en place cette boutique!
-  villager_trading_disabled: Les échanges avec les villageois ne sont pas autorisés
-    sur ce serveur!
-  not_allowed_to_link_sharesigns: Vous n'êtes pas autorisé à lier les signes partagés
-    à ce magasin!
+  villager_trading_disabled: Les échanges avec les villageois ne sont pas autorisés sur ce serveur!
+  not_allowed_to_link_sharesigns: Vous n'êtes pas autorisé à lier les signes partagés à ce magasin!
   no_shop_linked_to_sharesign: Ce signe Partagez n'a pas été lié à tous les magasins!
-  share_sign_splits_profit: Ce signe se partage les bénéfices entre les !profits pour
-    la boutique (s) à !profitshops!
-  registered_share_sign: Pour inscrire le signe Partager, cliquer sur le signe magasin
-    le plus proche!
+  share_sign_splits_profit: Ce signe se partage les bénéfices entre les !profits pour la boutique (s) à !profitshops!
+  registered_share_sign: Pour inscrire le signe Partager, cliquer sur le signe magasin le plus proche!
   unlinked_share_sign: Signe Partager délié de la boutique!
   linked_share_sign: Signe Partager lié à la boutique avec succès!
-  not_allowed_to_link_restrictedsigns: Vous n'êtes pas autorisé à lier signes affectés
-    à ce magasin!
-  no_shop_linked_to_restrictedsign: Ce signe restreint n'a pas été lié à tous les
-    magasins!
-  registered_restricted_sign: Inscrit le signe restreint, s'il vous plaît cliquer
-    sur le signe magasin le plus proche!
+  not_allowed_to_link_restrictedsigns: Vous n'êtes pas autorisé à lier signes affectés à ce magasin!
+  no_shop_linked_to_restrictedsign: Ce signe restreint n'a pas été lié à tous les magasins!
+  registered_restricted_sign: Inscrit le signe restreint, s'il vous plaît cliquer sur le signe magasin le plus proche!
   unlinked_restricted_sign: Le signe restreint à été délié!
   linked_restricted_sign: Signe Restreint lié à la boutique avec succès!
-  restricted_sign_restricts: Ce signe Restreint limite l'utilisation de la boutique(s)
-    à !restrictedshops!
+  restricted_sign_restricts: Ce signe Restreint limite l'utilisation de la boutique(s) à !restrictedshops!
   towny_insufficient_funds: Manque de fonds dans le compte de la boutique!
-  towny_owner_not_mayor_or_assistant: Le propriétaire de la boutique n'est pas maire
-    ou adjoint d'une ville!
-  towny_owner_not_belong_to_town: Le propriétaire du magasin ne devrait pas appartenir
-    à une ville!
-  towny_bank_withdrawls_not_allowed: La configuration actuelle de Towny ne permet
-    pas des retraits bancaires!
+  towny_owner_not_mayor_or_assistant: Le propriétaire de la boutique n'est pas maire ou adjoint d'une ville!
+  towny_owner_not_belong_to_town: Le propriétaire du magasin ne devrait pas appartenir à une ville!
+  towny_bank_withdrawls_not_allowed: La configuration actuelle de Towny ne permet pas des retraits bancaires!
   restricted_from_using: Vous êtes limité dans l'utilisation de ce magasin!
-  restricted_but_owner: Vous n'êtes pas limité à l'utilisation de cette boutique car
-    vous êtes le propriétaire!
-  item_on_blacklist: L'article !blacklisted_item est sur LISTE NOIRE et ne peut donc
-    pas être utilisé!
-  item_on_blacklist_but_op: L'article !blacklisted_item est sur LISTE NOIRE, mais
-    vous êtes OP!
+  restricted_but_owner: Vous n'êtes pas limité à l'utilisation de cette boutique car vous êtes le propriétaire!
+  item_on_blacklist: L'article !blacklisted_item est sur LISTE NOIRE et ne peut donc pas être utilisé!
+  item_on_blacklist_but_op: L'article !blacklisted_item est sur LISTE NOIRE, mais vous êtes OP!
   shop_contains: Ce magasin contient !shopinventory @ !items pour !price!
   removed_location: Emplacement supprimé!
   stored_location: Emplacement de !block enregistré!
   stored_location_containable: Emplacement de !block contenant !items enregistré!
-  failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur
-    ci-haut!
-  price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire
-    d'économie Essentials. Il est donc variable.
+  failed_to_update_shop: Impossible de mettre à jour le magasin en raison de l'erreur ci-haut!
+  price_drawn_from_essentials: Veuillez noter que le prix est fourni par le gestionnaire d'économie Essentials. Il est donc variable.
+  shop_on_cooldown: Ce magasin termine une transaction. Veuillez patienter !cooldownleft secondes.


### PR DESCRIPTION
- Removed all \HEX codes and replaced them with proper accented characters
- Added a few missing translatable strings (many more remaining)
- Removed all "crédits" occurences. Not used anymore as per original english text
- Removed invalid keys in messages / errors ...