### PR TITLE
A couple features and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.2.5-dev</version>
+    <version>3.6.3</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.2.6-dev</version>
+    <version>3.6.3</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.3</version>
+    <version>3.6.2.6-dev</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
         </dependency>
         <dependency>
             <groupId>com.Zrips</groupId>
-            <artifactId>CMI</artifactId>
-            <version>8.5.1.2</version>
+            <artifactId>CMI-API</artifactId>
+            <version>9.0.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.makershaven</groupId>
     <artifactId>SignShop</artifactId>
-    <version>3.6.2.3-dev</version>
+    <version>3.6.2.5-dev</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/wargamer2010/signshop/Seller.java
+++ b/src/main/java/org/wargamer2010/signshop/Seller.java
@@ -6,6 +6,7 @@ import org.bukkit.block.Sign;
 import org.bukkit.inventory.ItemStack;
 import org.wargamer2010.signshop.blocks.SignShopBooks;
 import org.wargamer2010.signshop.blocks.SignShopItemMeta;
+import org.wargamer2010.signshop.player.PlayerCache;
 import org.wargamer2010.signshop.player.PlayerIdentifier;
 import org.wargamer2010.signshop.player.SignShopPlayer;
 import org.wargamer2010.signshop.util.itemUtil;
@@ -28,7 +29,7 @@ public class Seller {
 
     public Seller(PlayerIdentifier playerId, String sWorld, List<Block> pContainables, List<Block> pActivatables, ItemStack[] isChestItems, Location location,
             Map<String, String> pMiscProps, Boolean save) {
-        owner = new SignShopPlayer(playerId);
+        owner = PlayerCache.getPlayer(playerId);//new SignShopPlayer(playerId);
         world = sWorld;
 
         isItems = itemUtil.getBackupItemStack(isChestItems);

--- a/src/main/java/org/wargamer2010/signshop/Seller.java
+++ b/src/main/java/org/wargamer2010/signshop/Seller.java
@@ -208,4 +208,27 @@ public class Seller {
         return returnList;
     }
 
+
+    public String getInfo(){
+        String newLine = "\n";
+        StringBuilder sb = new StringBuilder();
+        sb.append("--ShopInfo--").append(newLine)
+                .append("  Owner: ").append(owner.getName()).append(newLine)
+                .append("  Sign Location: ").append(signshopUtil.convertLocationToString(getSignLocation())).append(newLine)
+                .append("  Container Locations: ");
+        for (Block block: containables){
+            sb.append("  ").append(signshopUtil.convertLocationToString(block.getLocation())).append(" ");
+        }
+        sb.append(newLine)
+                .append("  Activatable Locations: ");
+        for (Block block: activatables){
+            sb.append("  ").append(signshopUtil.convertLocationToString(block.getLocation())).append(" ");
+        }
+        sb.append(newLine)
+                .append("  Misc: ");
+        for (String key : miscProps.keySet())
+            sb.append("  ").append(key).append(": ").append(miscProps.get(key)).append(" ");
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/wargamer2010/signshop/SignShop.java
+++ b/src/main/java/org/wargamer2010/signshop/SignShop.java
@@ -276,6 +276,7 @@ public class SignShop extends JavaPlugin {
         commandDispatcher.registerHandler("list", HelpHandler.getInstance());
         commandDispatcher.registerHandler("unlink", UnlinkHandler.getInstance());
         commandDispatcher.registerHandler("", HelpHandler.getInstance());
+        commandDispatcher.registerHandler("ignore", IgnoreHandler.getInstance());
     }
 
     private void registerSSListeners() {

--- a/src/main/java/org/wargamer2010/signshop/commands/IgnoreHandler.java
+++ b/src/main/java/org/wargamer2010/signshop/commands/IgnoreHandler.java
@@ -1,0 +1,33 @@
+package org.wargamer2010.signshop.commands;
+
+import org.bukkit.ChatColor;
+import org.wargamer2010.signshop.player.SignShopPlayer;
+
+public class IgnoreHandler implements ICommandHandler{
+    private static final ICommandHandler instance = new IgnoreHandler();
+
+    private IgnoreHandler(){
+
+    }
+
+    public static ICommandHandler getInstance() {
+        return instance;
+    }
+
+    @Override
+    public boolean handle(String command, String[] args, SignShopPlayer signShopPlayer) {
+        boolean wasIgnoring = signShopPlayer.isIgnoreMessages();
+
+        if (!wasIgnoring) {
+            signShopPlayer.sendNonDelayedMessage(ChatColor.RED + "You are now ignoring SignShop messages.");
+        }
+
+        signShopPlayer.setIgnoreMessages(!wasIgnoring);
+
+        if (wasIgnoring) {
+            signShopPlayer.sendNonDelayedMessage(ChatColor.GREEN + "You are no longer ignoring SignShop messages.");
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -2,6 +2,7 @@ package org.wargamer2010.signshop.configuration;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -12,6 +13,7 @@ import org.wargamer2010.signshop.operations.SignShopOperation;
 import org.wargamer2010.signshop.operations.SignShopOperationListItem;
 import org.wargamer2010.signshop.operations.runCommand;
 import org.wargamer2010.signshop.specialops.*;
+import org.wargamer2010.signshop.util.itemUtil;
 import org.wargamer2010.signshop.util.signshopUtil;
 
 import java.io.*;
@@ -134,7 +136,9 @@ public class SignShopConfig {
         Commands = configUtil.fetchListInHashmap("commands", config);
         DelayedCommands = configUtil.fetchListInHashmap("timedCommands", config);
         ShopLimits = configUtil.fetchStringIntegerHashMap("limits", config);
+        updateFormattedMaterials();
         setupBlacklist();
+        copyFileFromJar("materials.yml",false);
         copyFileFromJar("SSQuickReference.pdf", true);
         setupOperations();
         fixIncompleOperations();
@@ -864,6 +868,18 @@ public class SignShopConfig {
     }
 
 
+    private static void updateFormattedMaterials() {
+        File file = new File(SignShop.getInstance().getDataFolder(), "materials.yml");
+        FileConfiguration configuration = YamlConfiguration.loadConfiguration(file);
+        ConfigurationSection section = configuration.getConfigurationSection("materials");
+        if (section != null) {
+            for (String matString : section.getKeys(false)) {
+                Material matKey = Material.matchMaterial(matString);
+                String customName = section.getString(matString);
+                itemUtil.updateFormattedMaterial(matKey, ChatColor.translateAlternateColorCodes(SignShopConfig.getColorCode(), customName));
+            }
+        }
+    }
 
 
     private enum LanguageSpelling {

--- a/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
+++ b/src/main/java/org/wargamer2010/signshop/configuration/SignShopConfig.java
@@ -79,6 +79,7 @@ public class SignShopConfig {
     private static Material linkMaterial = Material.getMaterial("REDSTONE");
     private static Material updateMaterial = Material.getMaterial("INK_SAC");
     private static Material destroyMaterial = Material.getMaterial("GOLDEN_AXE");
+    private static Material inspectMaterial = Material.getMaterial("WRITABLE_BOOK");
 
 
     private SignShopConfig() {
@@ -249,6 +250,7 @@ public class SignShopConfig {
         linkMaterial = getMaterial(ymlThing.getString("LinkMaterial", "REDSTONE"), Material.getMaterial("REDSTONE"));
         updateMaterial = getMaterial(ymlThing.getString("UpdateMaterial", "INK_SAC"), Material.getMaterial("INK_SAC"));
         destroyMaterial = getMaterial(ymlThing.getString("DestroyMaterial", "GOLDEN_AXE"), Material.getMaterial("GOLDEN_AXE"));
+        inspectMaterial = getMaterial(ymlThing.getString("InspectMaterial", "WRITABLE_BOOK"), Material.getMaterial("WRITABLE_BOOK"));
 
         TextColor = ChatColor.getByChar(ymlThing.getString("ItemColor", "e").replace(ColorCode,""));
         if (TextColor == null) TextColor = ChatColor.YELLOW;
@@ -804,6 +806,10 @@ public class SignShopConfig {
 
     public static boolean isOPMaterial(Material check) {
         return (check == updateMaterial || check == linkMaterial);
+    }
+
+    public static boolean isInspectionMaterial(ItemStack item) {
+        return (item !=null && item.getType() == inspectMaterial);
     }
 
     public static Material getLinkMaterial() {

--- a/src/main/java/org/wargamer2010/signshop/listeners/EssentialsHelper.java
+++ b/src/main/java/org/wargamer2010/signshop/listeners/EssentialsHelper.java
@@ -32,6 +32,7 @@ class EssentialsHelper {
                 return;
             if(!settings.areSignsDisabled()) {
                 SignShop.log("Essentials signs are enabled, checking for conflicts now!", Level.WARNING);
+                SignShop.log("Even if no conflicts are found, it is recommended to disable all of Essentials signs including -color!", Level.WARNING);
                 FileConfiguration config = ess.getConfig();
                 if(config == null)
                     return;

--- a/src/main/java/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
+++ b/src/main/java/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
@@ -35,10 +35,7 @@ import org.wargamer2010.signshop.util.economyUtil;
 import org.wargamer2010.signshop.util.itemUtil;
 import org.wargamer2010.signshop.util.signshopUtil;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class SignShopPlayerListener implements Listener {
     private static final String helpPrefix = "help_";
@@ -232,6 +229,14 @@ public class SignShopPlayerListener implements Listener {
                 return;
             }
             signshopUtil.registerClickedMaterial(event);
+        } else if(event.getAction() == Action.RIGHT_CLICK_BLOCK && seller != null && SignShopConfig.isInspectionMaterial(event.getItem())){
+            SignShopPlayer signShopPlayer = PlayerCache.getPlayer(event.getPlayer());
+            if (playerCanInspect(seller,signShopPlayer)) {
+                signShopPlayer.sendMessage(seller.getInfo());
+            }
+            else {
+                signShopPlayer.sendMessage(SignShopConfig.getError("no_permission_to_inspect_shop",null));
+            }
         } else if(itemUtil.clickedSign(bClicked) && seller != null && (event.getItem() == null || !SignShopConfig.isOPMaterial(event.getItem().getType()))) {
             SignShopPlayer ssOwner = seller.getOwner();
             sLines = ((Sign) bClicked.getState()).getLines();
@@ -345,6 +350,11 @@ public class SignShopPlayerListener implements Listener {
                 }
             }
         }
+    }
+
+    private boolean playerCanInspect(Seller seller, SignShopPlayer signShopPlayer){
+              return ((signShopPlayer.isOwner(seller) && signShopPlayer.hasPerm("Signshop.Inspect.Own",false))
+                || signShopPlayer.isOp() || signShopPlayer.hasPerm("Signshop.Inspect.Others",true));
     }
 
 }

--- a/src/main/java/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
+++ b/src/main/java/org/wargamer2010/signshop/listeners/SignShopPlayerListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.wargamer2010.signshop.Seller;
 import org.wargamer2010.signshop.SignShop;
 import org.wargamer2010.signshop.configuration.SignShopConfig;
@@ -148,6 +149,12 @@ public class SignShopPlayerListener implements Listener {
                 SignShop.getCommandDispatcher().handle("sign", args, ssPlayer);
             }
         }
+    }
+
+    @EventHandler
+    public void onPlayerLeave(PlayerQuitEvent event){
+        SignShopPlayer signShopPlayer = PlayerCache.getPlayer(event.getPlayer());
+        signShopPlayer.setIgnoreMessages(false);
     }
 
     @EventHandler(priority = EventPriority.HIGH)

--- a/src/main/java/org/wargamer2010/signshop/listeners/sslisteners/SimpleShopProtector.java
+++ b/src/main/java/org/wargamer2010/signshop/listeners/sslisteners/SimpleShopProtector.java
@@ -70,6 +70,7 @@ public class SimpleShopProtector implements Listener {
         containables.remove(toUnlink);
         activatables.remove(toUnlink);
 
+        //Do not use the PlayerCache for this. It will make them ignore messages permanently.
         SignShopPlayer ssPlayer = new SignShopPlayer(seller.getOwner().GetIdentifier());
         ssPlayer.setIgnoreMessages(true);
 

--- a/src/main/java/org/wargamer2010/signshop/operations/promotePlayer.java
+++ b/src/main/java/org/wargamer2010/signshop/operations/promotePlayer.java
@@ -73,6 +73,7 @@ public class promotePlayer implements SignShopOperation {
         ssArgs.setMessagePart("!promoteto", groupOnSign);
         ssArgs.setMessagePart("!promotefrom", primaryGroup);
 
+        System.out.println("Primary Group: "+Vault.getGlobalPrimaryGroup(player));
         if(!Vault.removeGroupAnyWorld(player, primaryGroup)) {
             ssArgs.getPlayer().get().sendMessage(SignShopConfig.getError("could_not_remove_primary_group", ssArgs.getMessageParts()));
             return false;

--- a/src/main/java/org/wargamer2010/signshop/player/PlayerCache.java
+++ b/src/main/java/org/wargamer2010/signshop/player/PlayerCache.java
@@ -17,6 +17,11 @@ public class PlayerCache {
         return cachedPlayers.get(cachedIdentifiers.get(player.getUniqueId()));
     }
 
+    public static SignShopPlayer getPlayer(PlayerIdentifier playerIdentifier){
+        cachedPlayers.computeIfAbsent(playerIdentifier, v -> new SignShopPlayer(playerIdentifier));
+        return cachedPlayers.get(playerIdentifier);
+    }
+
     public static void removeFromCache(Player player) {
         cachedPlayers.remove(cachedIdentifiers.get(player.getUniqueId()));
         cachedIdentifiers.remove(player.getUniqueId());

--- a/src/main/java/org/wargamer2010/signshop/player/PlayerIdentifier.java
+++ b/src/main/java/org/wargamer2010/signshop/player/PlayerIdentifier.java
@@ -8,7 +8,7 @@ import org.bukkit.entity.Player;
 import java.lang.reflect.Method;
 import java.util.UUID;
 
-public class PlayerIdentifier {
+public class PlayerIdentifier { //TODO completely switch over to UUID support instead of PlayerIdentifier
     private static boolean didMethodLookup = false;
     private static boolean uuidSupport = false;
     private UUID id = null;
@@ -78,7 +78,7 @@ public class PlayerIdentifier {
 
         if(GetUUIDSupport()) {
             try {
-                return new SignShopPlayer(new PlayerIdentifier(UUID.fromString(string)));
+                return PlayerCache.getPlayer(new PlayerIdentifier(UUID.fromString(string)));
             } catch(IllegalArgumentException ex) {
                 // Legacy mode, name will be converted to UUID on next Save
             }

--- a/src/main/java/org/wargamer2010/signshop/player/SignShopPlayer.java
+++ b/src/main/java/org/wargamer2010/signshop/player/SignShopPlayer.java
@@ -79,7 +79,7 @@ public class SignShopPlayer {
     }
 
     public void sendMessage(String sMessage) {
-        if (sMessage == null || sMessage.trim().isEmpty() || getPlayer() == null)
+        if (sMessage == null || sMessage.trim().isEmpty() || getPlayer() == null || ignoreMessages)
             return;
         if (SignShopConfig.getMessageCooldown() <= 0) {
             sendNonDelayedMessage(sMessage);

--- a/src/main/java/org/wargamer2010/signshop/util/commandUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/commandUtil.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.wargamer2010.signshop.SignShop;
 import org.wargamer2010.signshop.commands.CommandDispatcher;
+import org.wargamer2010.signshop.player.PlayerCache;
 import org.wargamer2010.signshop.player.SignShopPlayer;
 
 import java.util.Collection;
@@ -105,9 +106,11 @@ public class commandUtil {
     }
 
     public static boolean handleCommand(CommandSender sender, Command cmd, String commandLabel, String[] args, CommandDispatcher commandDispatcher) {
-        SignShopPlayer player = null;
-        if(sender instanceof Player)
-            player = new SignShopPlayer((Player) sender);
+        SignShopPlayer signShopPlayer = null;
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
+            signShopPlayer = PlayerCache.getPlayer(player);
+        }
         String[] remainingArgs;
         String subCommandName;
         if(args.length == 0) {
@@ -121,6 +124,6 @@ public class commandUtil {
                     remainingArgs[i-1] = args[i].toLowerCase();
             }
         }
-        return commandDispatcher.handle(subCommandName, remainingArgs, player);
+        return commandDispatcher.handle(subCommandName, remainingArgs, signShopPlayer);
     }
 }

--- a/src/main/java/org/wargamer2010/signshop/util/itemUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/itemUtil.java
@@ -31,6 +31,11 @@ import java.util.regex.Pattern;
 
 /** @noinspection deprecation*/ //TODO Remove deprecated calls
 public class itemUtil {
+    public static Map<Material,String> formattedMaterials = new HashMap<>();
+
+    static {
+        initializeFormattedMaterialMap();
+    }
 
     private itemUtil() {
 
@@ -145,7 +150,23 @@ public class itemUtil {
        return formatMaterialName(block.getType());
     }
 
+
+
+    private static void initializeFormattedMaterialMap(){
+        for (Material mat:Material.values()){
+            formattedMaterials.putIfAbsent(mat,formatMaterialName(mat));
+        }
+    }
+
+    public static void updateFormattedMaterial(Material material,String string){
+        formattedMaterials.replace(material,string);
+    }
+
     private static String formatMaterialName(Material material) {
+        if(formattedMaterials.containsKey(material)) {
+            return formattedMaterials.get(material);
+        }
+
         String sData;
         sData = material.toString().toLowerCase();
         Pattern p = Pattern.compile("\\(-?[0-9]+\\)");

--- a/src/main/java/org/wargamer2010/signshop/util/signshopUtil.java
+++ b/src/main/java/org/wargamer2010/signshop/util/signshopUtil.java
@@ -120,7 +120,7 @@ public class signshopUtil {
             Enchantment enchantment;
             int enchantmentLevel;
             String[] enchantmentPair = singleEnchantmentString.split("\\|");
-            enchantment = Enchantment.getByKey(NamespacedKey.minecraft(enchantmentPair[0]));
+            enchantment = Enchantment.getByKey(NamespacedKey.minecraft(enchantmentPair[0].toLowerCase()));
             try {
                 enchantmentLevel = Integer.parseInt(enchantmentPair[1]);
                 enchantmentsMap.put(enchantment, enchantmentLevel);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,6 +43,8 @@ UpdateMaterial: ink_sac
 # Used to destroy shops in creative mode if "ProtectShopsInCreative" is set to "true"
 DestroyMaterial: golden_axe
 
+# Used to see extra information about a shop(Permission or Op required)
+InspectMaterial: writable_book
 
 #----------- Language ------------------
 
@@ -635,6 +637,7 @@ errors:
   exceeded_max_amount_of_chests_per_shop: You have exceeded the maximum amount of chests (!maxAmountOfChests) that can be linked to a single shop. Please unlink one or more before continuing.
   this_shop_exceeded_max_amount_of_chests: Shop in world '!world' at (!x, !y, !z) exceeds the maximum amount of chests per shop!
   could_not_complete_operation: Could not complete operation, contact your System Administrator and checks the logs.
+  no_permission_to_inspect_shop: You do not have permission to inspect this shop.
 
 # Used for checking if the config needs to be backed up before upgrading it. (Do not modify unless told to do so)
 ConfigVersionDoNotTouch: 3

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -224,7 +224,6 @@ messages:
 
 # Ces messages sont utilisés par la commande /signshop sign SIGNNAME
 # De nouvelles lignes sont automatiquement faites à la fin des phrases au moment de l'affichage.
-# TODO / A FAIRE
   help:
     Buy: Le panneau Acheter échange l'argent du client contre des items dans le coffre. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction.
     Sell: Le panneau Vendre échange les items du client contre l'argent du propriétaire de la boutique. Sur la 2ème et la 3ème ligne, vous pouvez inscrire ce que vous voulez. Sur la 4ème ligne, inscrivez le prix. Avec !linkmaterial, frappez le coffre contenant le type et la quantité d'items compris dans une seule transaction.

--- a/src/main/resources/materials.yml
+++ b/src/main/resources/materials.yml
@@ -1,0 +1,12 @@
+# In this file you can customize the material names!
+# Simply put the material name you want to customize with the custom name in quotes after the colon.
+
+# Valid material names can be found here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
+
+# Remove the '#' from the following examples and edit and add to them to your liking.
+materials:
+#  DIAMOND: "&bDiamond"
+#  EMERALD: "&4&n&lYour translation of &r&aEMERALD"
+#  IRON_ORE: "铁矿"
+#  DIAMOND_SWORD: "Excalibur"
+#  BLUE_STAINED_GLASS: "&1Stained Glass"


### PR DESCRIPTION
Adds ignore SignShop command to allow busy shop owners to ignore the messages that players are using their shops. Formatted material names can now be customized and/or translated, also includes a slight performance boost by caching the formatted materials. Switches the pom to use CMI-API so we no longer need to have purchased CMI to compile. Adds inspection tool to give information about a shop by clicking with book and quill by default.